### PR TITLE
dftranspose speedup

### DIFF
--- a/Example_Systems/SmallNewEngland/OneZone/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone/Settings/genx_settings.yml
@@ -1,4 +1,4 @@
-MacOrWindows: Mac  # Set to either "Mac" (also works for Linux) or "Windows" to ensure use of proper file directory separator "\" or "/
+MacOrWindows: Windows  # Set to either "Mac" (also works for Linux) or "Windows" to ensure use of proper file directory separator "\" or "/
 PrintModel: 0 # Write the model formulation as an output; 0 = active; 1 = not active
 NetworkExpansion: 0 # Transmission network expansionl; 0 = not active; 1 = active systemwide
 Trans_Loss_Segments: 1 # Number of segments used in piecewise linear approximation of transmission losses; 1 = linear, >2 = piecewise quadratic

--- a/Example_Systems/SmallNewEngland/OneZone/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone/Settings/genx_settings.yml
@@ -1,4 +1,4 @@
-MacOrWindows: Windows  # Set to either "Mac" (also works for Linux) or "Windows" to ensure use of proper file directory separator "\" or "/
+MacOrWindows: Mac  # Set to either "Mac" (also works for Linux) or "Windows" to ensure use of proper file directory separator "\" or "/
 PrintModel: 0 # Write the model formulation as an output; 0 = active; 1 = not active
 NetworkExpansion: 0 # Transmission network expansionl; 0 = not active; 1 = active systemwide
 Trans_Loss_Segments: 1 # Number of segments used in piecewise linear approximation of transmission losses; 1 = linear, >2 = piecewise quadratic

--- a/src/write_outputs/dftranspose.jl
+++ b/src/write_outputs/dftranspose.jl
@@ -26,33 +26,49 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 ## Note this function is necessary because no stock function to transpose
 ## DataFrames appears to exist.
 ################################################################################
+"""
+   df = dftranspose(df::DataFrame, withhead::Bool)
 
+Returns a transpose of a Dataframe.\n
+Uses approx 
+FIXME: This is for DataFrames@0.20.2, as used in GenX. 
+Versions 0.21+ could use stack and unstack to make further changes while retaining the order
+"""
 function dftranspose(df::DataFrame, withhead::Bool)
-	# Extract old column names (as Symbols)
-	oldnames_temp = names(df)
-	# Convert to String vector and save for use as new row names
-	oldnames = Vector{Union{Nothing,String}}(nothing, length(oldnames_temp))
-	for r in 1:length(oldnames_temp)
-		oldnames[r] = String(oldnames_temp[r])
-	end
-	if(withhead)
-		# Extract first row of data frame (Resources names) (as Strings) and save as new column names
-		newnames = string.(df[:,1])
-		startcol=2
+	if withhead
+		colnames = cat(:Row, Symbol.(df[!,1]), dims=1)
+		return DataFrame([[names(df)]; collect.(eachrow(df))], colnames)
 	else
-		startcol=1
+		return DataFrame([[names(df)]; collect.(eachrow(df))], [:Row; Symbol.("x",axes(df, 1))])
 	end
-	# Collect each of the old columns and tranpose to new rows
-	t = DataFrame(permutedims(df[:,startcol]))
-	for c in (startcol+1):ncol(df)
-		t = vcat(t,DataFrame(permutedims(df[:,c])))
-	end
-	# Set new column names
-	if(withhead)
-		t = DataFrame(t,Symbol(newnames[c]))
-	end
-	# Add new row names vector to data frame
-	t = hcat(DataFrame(Row=oldnames[startcol:length(oldnames)]), t)
-	# Return transposed data frame
-	return t
 end # End dftranpose()
+
+# function dftranspose(df::DataFrame, withhead::Bool)
+# 	# Extract old column names (as Symbols)
+# 	oldnames_temp = names(df)
+# 	# Convert to String vector and save for use as new row names
+# 	oldnames = Vector{Union{Nothing,String}}(nothing, length(oldnames_temp))
+# 	for r in 1:length(oldnames_temp)
+# 		oldnames[r] = String(oldnames_temp[r])
+# 	end
+# 	if(withhead)
+# 		# Extract first row of data frame (Resources names) (as Strings) and save as new column names
+# 		newnames = string.(df[:,1])
+# 		startcol=2
+# 	else
+# 		startcol=1
+# 	end
+# 	# Collect each of the old columns and tranpose to new rows
+# 	t = DataFrame(permutedims(df[:,startcol]))
+# 	for c in (startcol+1):ncol(df)
+# 		t = vcat(t,DataFrame(permutedims(df[:,c])))
+# 	end
+# 	# Set new column names
+# 	if(withhead)
+# 		t = DataFrame(t,Symbol(newnames[c]))
+# 	end
+# 	# Add new row names vector to data frame
+# 	t = hcat(DataFrame(Row=oldnames[startcol:length(oldnames)]), t)
+# 	# Return transposed data frame
+# 	return t
+# end # End dftranpose()

--- a/src/write_outputs/dftranspose.jl
+++ b/src/write_outputs/dftranspose.jl
@@ -42,33 +42,3 @@ function dftranspose(df::DataFrame, withhead::Bool)
 		return DataFrame([[names(df)]; collect.(eachrow(df))], [:Row; Symbol.("x",axes(df, 1))])
 	end
 end # End dftranpose()
-
-# function dftranspose(df::DataFrame, withhead::Bool)
-# 	# Extract old column names (as Symbols)
-# 	oldnames_temp = names(df)
-# 	# Convert to String vector and save for use as new row names
-# 	oldnames = Vector{Union{Nothing,String}}(nothing, length(oldnames_temp))
-# 	for r in 1:length(oldnames_temp)
-# 		oldnames[r] = String(oldnames_temp[r])
-# 	end
-# 	if(withhead)
-# 		# Extract first row of data frame (Resources names) (as Strings) and save as new column names
-# 		newnames = string.(df[:,1])
-# 		startcol=2
-# 	else
-# 		startcol=1
-# 	end
-# 	# Collect each of the old columns and tranpose to new rows
-# 	t = DataFrame(permutedims(df[:,startcol]))
-# 	for c in (startcol+1):ncol(df)
-# 		t = vcat(t,DataFrame(permutedims(df[:,c])))
-# 	end
-# 	# Set new column names
-# 	if(withhead)
-# 		t = DataFrame(t,Symbol(newnames[c]))
-# 	end
-# 	# Add new row names vector to data frame
-# 	t = hcat(DataFrame(Row=oldnames[startcol:length(oldnames)]), t)
-# 	# Return transposed data frame
-# 	return t
-# end # End dftranpose()

--- a/src/write_outputs/dftranspose.jl
+++ b/src/write_outputs/dftranspose.jl
@@ -30,7 +30,6 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
    df = dftranspose(df::DataFrame, withhead::Bool)
 
 Returns a transpose of a Dataframe.\n
-Uses approx 
 FIXME: This is for DataFrames@0.20.2, as used in GenX. 
 Versions 0.21+ could use stack and unstack to make further changes while retaining the order
 """


### PR DESCRIPTION
Speeds up and reduces memory requirement of dftranspose.

Tested on the SmallNewEngland example cases and returned the same CSV files. Saw at least a 10x speedup and reduction in memory usage during the output writes. Separately tested on larger results and memory improvements appeared to increase.
Tested using the current JuliaGenXEnv modules, in particular DataFrames v0.20.2. Later versions may require a rewrite, but will also allow more flexibility in how the tranpose handles ordering or other issues.

Changes to genx_settings.yml can be rejected. Just Windows vs Mac setting. 