### PR TITLE
Corrected the GenX version in Project.toml to 0.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Jesse Jenkins", "Nestor Sepulveda", "Dharik Mallapragada", "Aaron Schwartz", "Neha Patankar", "Qingyu Xu", "Jack Morris", "Sambuddha Chakrabarti"]
-version = "1.0.0"
+version = "0.1.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
The Project.toml GenX version was set at 1.0.0. This PR corrects it to version 0.1.0 according to the latest release.