### PR TITLE
Simpify run scripts

### DIFF
--- a/Example_Systems/RealSystemExample/ISONE_Singlezone/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Singlezone/Run.jl
@@ -57,7 +57,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model

--- a/Example_Systems/RealSystemExample/ISONE_Trizone/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone/Run.jl
@@ -54,7 +54,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Run.jl
@@ -54,7 +54,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model

--- a/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Run.jl
+++ b/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Run.jl
@@ -54,7 +54,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model

--- a/Example_Systems/SmallNewEngland/OneZone/Run.jl
+++ b/Example_Systems/SmallNewEngland/OneZone/Run.jl
@@ -55,7 +55,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model

--- a/Example_Systems/SmallNewEngland/OneZone_3VREBin/Run.jl
+++ b/Example_Systems/SmallNewEngland/OneZone_3VREBin/Run.jl
@@ -54,7 +54,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model

--- a/Example_Systems/SmallNewEngland/ThreeZones/Run.jl
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Run.jl
@@ -54,7 +54,7 @@ OPTIMIZER = configure_solver(mysetup["Solver"], settings_path)
 
 ### Load inputs
 println("Loading Inputs")
-myinputs = Dict() # myinputs dictionary will store read-in data and computed parameters
+# myinputs dictionary will store read-in data and computed parameters
 myinputs = load_inputs(mysetup, inpath)
 
 ### Generate model


### PR DESCRIPTION
In all the example Run.jl scripts, the line myinputs = Dict() did nothing because it is immediately
overwritten on the next line by the load_inputs function. This simplifies the scripts and reduces possible confusion as to why the line is there.

This addresses #71 .