### PR TITLE
Add a default for MultiStage to settings

### DIFF
--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -63,6 +63,8 @@ function configure_settings(settings_path::String)
     set_default_if_absent!(settings, "ModelingToGenerateAlternatives", 0)
     # Slack value as a fraction of least-cost objective in budget constraint used for evaluating alternative model solutions; positive float value
     set_default_if_absent!(settings, "ModelingtoGenerateAlternativeSlack", 0.1)
+    # Multistage expansion; 0 = Single-stage GenX; 1 = Multi-stage GenX
+    set_default_if_absent!(settings, "MultiStage", 0)
 
 return settings
 end

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -14,49 +14,55 @@ in LICENSE.txt.  Users uncompressing this from an archive may not have
 received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+function set_default_if_absent!(settings::Dict, key::String, defaultval)
+    if !haskey(settings, key)
+        settings[key] = defaultval
+    end
+end
+
 function configure_settings(settings_path::String)
 
     settings = YAML.load(open(settings_path))
 
     # Optional settings parameters ############################################
-	#Write the model formulation as an output; 0 = active; 1 = not active
-    if(!haskey(settings, "PrintModel")) settings["PrintModel"] = 0  end
+    #Write the model formulation as an output; 0 = active; 1 = not active
+    set_default_if_absent!(settings, "PrintModel", 0)
     # Transmission network expansionl; 0 = not active; 1 = active systemwide
-    if(!haskey(settings, "NetworkExpansion")) settings["NetworkExpansion"] = 0 end
+    set_default_if_absent!(settings, "NetworkExpansion", 0)
     # Number of segments used in piecewise linear approximation of transmission losses; 1 = linear, >2 = piecewise quadratic
-    if(!haskey(settings, "Trans_Loss_Segments")) settings["Trans_Loss_Segments"] = 1 end
+    set_default_if_absent!(settings, "Trans_Loss_Segments", 1)
     # Regulation (primary) and operating (secondary) reserves; 0 = not active, 1 = active systemwide
-    if(!haskey(settings, "Reserves")) settings["Reserves"] = 0 end
+    set_default_if_absent!(settings, "Reserves", 0)
     # Minimum qualifying renewables penetration; 0 = not active; 1 = active systemwide
-    if(!haskey(settings, "EnergyShareRequirement")) settings["EnergyShareRequirement"] = 0 end
+    set_default_if_absent!(settings, "EnergyShareRequirement", 0)
     # Number of capacity reserve margin constraints; 0 = not active; 1 = active systemwide
-    if(!haskey(settings, "CapacityReserveMargin")) settings["CapacityReserveMargin"] = 0 end
+    set_default_if_absent!(settings, "CapacityReserveMargin", 0)
     # CO2 emissions cap; 0 = not active (no CO2 emission limit); 1 = mass-based emission limit constraint; 2 = load + rate-based emission limit constraint; 3 = generation + rate-based emission limit constraint
-    if(!haskey(settings, "CO2Cap")) settings["CO2Cap"] = 0 end
+    set_default_if_absent!(settings, "CO2Cap", 0)
     # Energy Share Requirement and CO2 constraints account for energy lost; 0 = not active (DO NOT account for energy lost); 1 = active systemwide (DO account for energy lost)
-    if(!haskey(settings, "StorageLosses")) settings["StorageLosses"] = 1 end
+    set_default_if_absent!(settings, "StorageLosses", 1)
     # Activate minimum technology carveout constraints; 0 = not active; 1 = active
-    if(!haskey(settings, "MinCapReq")) settings["MinCapReq"] = 0 end
+    set_default_if_absent!(settings, "MinCapReq", 0)
     # Available solvers: Gurobi, CPLEX, CLPs
-    if(!haskey(settings, "Solver")) settings["Solver"] =  "Gurobi" end
+    set_default_if_absent!(settings, "Solver", "Gurobi")
     # Turn on parameter scaling wherein load, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
-    if(!haskey(settings, "ParameterScale")) settings["ParameterScale"] = 0 end
+    set_default_if_absent!(settings, "ParameterScale", 0)
     # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
-    if(!haskey(settings, "WriteShadowPrices")) settings["WriteShadowPrices"] = 0 end
+    set_default_if_absent!(settings, "WriteShadowPrices", 0)
     # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
-    if(!haskey(settings, "UCommit")) settings["UCommit"] = 0 end
+    set_default_if_absent!(settings, "UCommit", 0)
     # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-    if(!haskey(settings, "OperationWrapping")) settings["OperationWrapping"] = 0 end
+    set_default_if_absent!(settings, "OperationWrapping", 0)
     # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
-    if(!haskey(settings, "LongDurationStorage")) settings["LongDurationStorage"] = 0 end
+    set_default_if_absent!(settings, "LongDurationStorage", 0)
     # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
-    if(!haskey(settings, "TimeDomainReductionFolder")) settings["TimeDomainReductionFolder"] = "TDR_Results"  end
+    set_default_if_absent!(settings, "TimeDomainReductionFolder", "TDR_Results")
     # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
-    if(!haskey(settings, "TimeDomainReduction")) settings["TimeDomainReduction"] = 0 end
+    set_default_if_absent!(settings, "TimeDomainReduction", 0)
     # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output
-    if(!haskey(settings, "ModelingToGenerateAlternatives")) settings["ModelingToGenerateAlternatives"] = 0 end
+    set_default_if_absent!(settings, "ModelingToGenerateAlternatives", 0)
     # Slack value as a fraction of least-cost objective in budget constraint used for evaluating alternative model solutions; positive float value
-    if(!haskey(settings, "ModelingtoGenerateAlternativeSlack")) settings["ModelingtoGenerateAlternativeSlack"] = 0.1 end
+    set_default_if_absent!(settings, "ModelingtoGenerateAlternativeSlack", 0.1)
 
 return settings
 end


### PR DESCRIPTION
The new `MultiStage` setting had no default, so if cases did not previously have it set in the `genx_settings.yml` file they would fail. This sets a default equal to 0 (for single-stage GenX).

This fixes #89 .

I also wrote a short function to make the rest of the `configure_settings` function easier to read and/or modify.
In the future this could, for example, be used to announce/log that it default setting choices are being made.