### PR TITLE
Simplify loading scripts: use joinpath

### DIFF
--- a/src/load_inputs/load_cap_reserve_margin.jl
+++ b/src/load_inputs/load_cap_reserve_margin.jl
@@ -15,16 +15,15 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_cap_reserve_margin(setup::Dict, path::AbstractString, sep::AbstractString, inputs_crm::Dict, network_var::DataFrame)
+	load_cap_reserve_margin(setup::Dict, path::AbstractString, inputs_crm::Dict, network_var::DataFrame)
 
 Function for reading input parameters related to planning reserve margin constraints
 """
-function load_cap_reserve_margin(setup::Dict, path::AbstractString, sep::AbstractString, inputs_crm::Dict)
+function load_cap_reserve_margin(setup::Dict, path::AbstractString, inputs_crm::Dict)
 	# Definition of capacity reserve margin (crm) by locational deliverability area (LDA)
 	println("About to read Capacity_reserve_margin.csv")
 
-	#inputs_crm["dfCapRes"] = CSV.read(string(path,sep,"Capacity_reserve_margin.csv"), header=true)
-	inputs_crm["dfCapRes"] = DataFrame(CSV.File(string(path, sep,"Capacity_reserve_margin.csv"), header=true), copycols=true)
+	inputs_crm["dfCapRes"] = DataFrame(CSV.File(joinpath(path, "Capacity_reserve_margin.csv"), header=true), copycols=true)
 
 	# Ensure float format values:
 
@@ -42,7 +41,7 @@ function load_cap_reserve_margin(setup::Dict, path::AbstractString, sep::Abstrac
 	return inputs_crm
 end
 
-function load_cap_reserve_margin_trans(setup::Dict, path::AbstractString, sep::AbstractString, inputs_crm::Dict, network_var::DataFrame)
+function load_cap_reserve_margin_trans(setup::Dict, path::AbstractString, inputs_crm::Dict, network_var::DataFrame)
 
 	println("About to Read Transmission's Participation in Capacity Reserve Margin")
 

--- a/src/load_inputs/load_co2_cap.jl
+++ b/src/load_inputs/load_co2_cap.jl
@@ -15,14 +15,13 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_co2_cap(setup::Dict, path::AbstractString, sep::AbstractString, inputs_co2::Dict)
+	load_co2_cap(setup::Dict, path::AbstractString, inputs_co2::Dict)
 
 Function for reading input parameters related to CO$_2$ emissions cap constraints
 """
-function load_co2_cap(setup::Dict, path::AbstractString, sep::AbstractString, inputs_co2::Dict)
+function load_co2_cap(setup::Dict, path::AbstractString, inputs_co2::Dict)
 	# Definition of Cap requirements by zone (as Max Mtons)
-	#inputs_co2["dfCO2Cap"] = CSV.read(string(path,sep,"CO2_cap.csv"), header=true)
-	inputs_co2["dfCO2Cap"] = DataFrame(CSV.File(string(path, sep,"CO2_cap.csv"), header=true), copycols=true)
+	inputs_co2["dfCO2Cap"] = DataFrame(CSV.File(joinpath(path,"CO2_cap.csv"), header=true), copycols=true)
 	cap = count(s -> startswith(String(s), "CO_2_Cap_Zone"), names(inputs_co2["dfCO2Cap"]))
 	first_col = findall(s -> s == "CO_2_Cap_Zone_1", names(inputs_co2["dfCO2Cap"]))[1]
 	last_col = findall(s -> s == "CO_2_Cap_Zone_$cap", names(inputs_co2["dfCO2Cap"]))[1]

--- a/src/load_inputs/load_energy_share_requirement.jl
+++ b/src/load_inputs/load_energy_share_requirement.jl
@@ -15,15 +15,14 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_energy_share_requirement(setup::Dict, path::AbstractString, sep::AbstractString, inputs_ESR::Dict)
+	load_energy_share_requirement(setup::Dict, path::AbstractString, inputs_ESR::Dict)
 
 Function for reading input parameters related to mimimum energy share requirement constraints (e.g. renewable portfolio standard or clean electricity standard policies)
 """
-function load_energy_share_requirement(setup::Dict, path::AbstractString, sep::AbstractString, inputs_ESR::Dict)
+function load_energy_share_requirement(setup::Dict, path::AbstractString, inputs_ESR::Dict)
 	# Definition of ESR requirements by zone (as % of load)
 	# e.g. any policy requiring a min share of qualifying resources (Renewable Portfolio Standards / Renewable Energy Obligations / Clean Energy Standards etc.)
-	#inputs_ESR["dfESR"] = CSV.read(string(path,sep,"Energy_share_requirement.csv"), header=true)
-	inputs_ESR["dfESR"] = DataFrame(CSV.File(string(path, sep,"Energy_share_requirement.csv"), header=true), copycols=true)
+	inputs_ESR["dfESR"] = DataFrame(CSV.File(joinpath(path,"Energy_share_requirement.csv"), header=true), copycols=true)
 	# Ensure float format values:
 	ESR = count(s -> startswith(String(s), "ESR"), names(inputs_ESR["dfESR"]))
 	first_col = findall(s -> s == "ESR_1", names(inputs_ESR["dfESR"]))[1]

--- a/src/load_inputs/load_fuels_data.jl
+++ b/src/load_inputs/load_fuels_data.jl
@@ -15,19 +15,19 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_fuels_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_fuel::Dict)
+	load_fuels_data(setup::Dict, path::AbstractString, inputs_fuel::Dict)
 
 Function for reading input parameters related to fuel costs and CO$_2$ content of fuels
 """
-function load_fuels_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_fuel::Dict)
+function load_fuels_data(setup::Dict, path::AbstractString, inputs_fuel::Dict)
 
 	# Fuel related inputs - read in different files depending on if time domain reduction is activated or not
 	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
 	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) # Use Time Domain Reduced data for GenX
-		fuels_in = DataFrame(CSV.File(string(joinpath(data_directory,"Fuels_data.csv")), header=true), copycols=true)
+		fuels_in = DataFrame(CSV.File(joinpath(data_directory,"Fuels_data.csv"), header=true), copycols=true)
 	else  # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
-		fuels_in = DataFrame(CSV.File(string(path,sep,"Fuels_data.csv"), header=true), copycols=true)
+		fuels_in = DataFrame(CSV.File(joinpath(path,"Fuels_data.csv"), header=true), copycols=true)
 	end
 
 	# Fuel costs .&  CO2 emissions rate for each fuel type (stored in dictionary objects)

--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -15,14 +15,14 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_generators_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
+	load_generators_data(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
 
 Function for reading input parameters related to electricity generators (plus storage and flexible demand resources)
 """
-function load_generators_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
+function load_generators_data(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
 
 	# Generator related inputs
-	gen_in = DataFrame(CSV.File(string(path,sep,"Generators_data.csv"), header=true), copycols=true)
+	gen_in = DataFrame(CSV.File(joinpath(path, "Generators_data.csv"), header=true), copycols=true)
 
 	# Add Resource IDs after reading to prevent user errors
 	gen_in[!,:R_ID] = 1:size(collect(skipmissing(gen_in[!,1])),1)

--- a/src/load_inputs/load_generators_variability.jl
+++ b/src/load_inputs/load_generators_variability.jl
@@ -15,19 +15,19 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_generators_variability(setup::Dict, path::AbstractString, sep::AbstractString, inputs_genvar::Dict)
+	load_generators_variability(setup::Dict, path::AbstractString, inputs_genvar::Dict)
 
 Function for reading input parameters related to hourly maximum capacity factors for all generators (plus storage and flexible demand resources)
 """
-function load_generators_variability(setup::Dict, path::AbstractString, sep::AbstractString, inputs_genvar::Dict)
+function load_generators_variability(setup::Dict, path::AbstractString, inputs_genvar::Dict)
 
 	# Hourly capacity factors
 	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
 	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) # Use Time Domain Reduced data for GenX
-		gen_var = DataFrame(CSV.File(string(joinpath(data_directory,"Generators_variability.csv")), header=true), copycols=true)
+		gen_var = DataFrame(CSV.File(joinpath(data_directory,"Generators_variability.csv"), header=true), copycols=true)
 	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
-		gen_var = DataFrame(CSV.File(string(path,sep,"Generators_variability.csv"), header=true), copycols=true)
+		gen_var = DataFrame(CSV.File(joinpath(path,"Generators_variability.csv"), header=true), copycols=true)
 	end
 
 	# Reorder DataFrame to R_ID order (order provided in Generators_data.csv)

--- a/src/load_inputs/load_inputs.jl
+++ b/src/load_inputs/load_inputs.jl
@@ -27,15 +27,6 @@ returns: Dict (dictionary) object containing all data inputs
 """
 function load_inputs(setup::Dict,path::AbstractString)
 
-	## Use appropriate directory separator depending on Mac or Windows config
-	if Sys.isunix()
-		sep = "/"
-    elseif Sys.iswindows()
-		sep = "\U005c"
-    else
-        sep = "/"
-	end
-
 	data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 
 	## Read input files
@@ -43,52 +34,52 @@ function load_inputs(setup::Dict,path::AbstractString)
 	## Declare Dict (dictionary) object used to store parameters
 	inputs = Dict()
 	# Read input data about power network topology, operating and expansion attributes
-    if isfile(string(path,sep,"Network.csv"))
-		inputs, network_var = load_network_data(setup, path, sep, inputs)
+    if isfile(joinpath(path,"Network.csv"))
+		inputs, network_var = load_network_data(setup, path, inputs)
 	else
 		inputs["Z"] = 1
 		inputs["L"] = 0
 	end
 
 	# Read temporal-resolved load data, and clustering information if relevant
-	inputs = load_load_data(setup, path, sep, inputs)
+	inputs = load_load_data(setup, path, inputs)
 	# Read fuel cost data, including time-varying fuel costs
-	inputs, cost_fuel, CO2_fuel = load_fuels_data(setup, path, sep, inputs)
+	inputs, cost_fuel, CO2_fuel = load_fuels_data(setup, path, inputs)
 	# Read in generator/resource related inputs
-	inputs = load_generators_data(setup, path, sep, inputs, cost_fuel, CO2_fuel)
+	inputs = load_generators_data(setup, path, inputs, cost_fuel, CO2_fuel)
 	# Read in generator/resource availability profiles
-	inputs = load_generators_variability(setup, path, sep, inputs)
+	inputs = load_generators_variability(setup, path, inputs)
 
 	if setup["CapacityReserveMargin"]==1
-		inputs = load_cap_reserve_margin(setup, path, sep, inputs)
+		inputs = load_cap_reserve_margin(setup, path, inputs)
 		if inputs["Z"] >1
-			inputs = load_cap_reserve_margin_trans(setup, path, sep, inputs,network_var)
+			inputs = load_cap_reserve_margin_trans(setup, path, inputs,network_var)
 		end
 	end
 
 	# Read in general configuration parameters for reserves (resource-specific reserve parameters are read in generators_data())
 	if setup["Reserves"]==1
-		inputs = load_reserves(setup, path, sep, inputs)
+		inputs = load_reserves(setup, path, inputs)
 	end
 
 	if setup["MinCapReq"] == 1
-		inputs = load_minimum_capacity_requirement(path,sep, inputs, setup)
+		inputs = load_minimum_capacity_requirement(path, inputs, setup)
 	end
 
 	if setup["EnergyShareRequirement"]==1
-		inputs = load_energy_share_requirement(setup, path, sep, inputs)
+		inputs = load_energy_share_requirement(setup, path, inputs)
 	end
 
 	if setup["CO2Cap"] >= 1
-		inputs = load_co2_cap(setup, path, sep, inputs)
+		inputs = load_co2_cap(setup, path, inputs)
 	end
 
 	# Read in mapping of modeled periods to representative periods
-	if setup["OperationWrapping"]==1 && !isempty(inputs["STOR_LONG_DURATION"]) && (isfile(data_directory*"/Period_map.csv") || isfile(joinpath(data_directory,string(joinpath(setup["TimeDomainReductionFolder"],"Period_map.csv"))))) # Use Time Domain Reduced data for GenX)
-		inputs = load_period_map(setup, path, sep, inputs)
+	if setup["OperationWrapping"]==1 && !isempty(inputs["STOR_LONG_DURATION"]) && (isfile(data_directory*"/Period_map.csv") || isfile(joinpath(data_directory,joinpath(setup["TimeDomainReductionFolder"],"Period_map.csv")))) # Use Time Domain Reduced data for GenX)
+		inputs = load_period_map(setup, path, inputs)
 	end
 
-	println("CSV Files Successfully Read In From $path$sep")
+	println("CSV Files Successfully Read In From $path")
 
 	return inputs
 end

--- a/src/load_inputs/load_load_data.jl
+++ b/src/load_inputs/load_load_data.jl
@@ -15,19 +15,19 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_load::Dict)
+	load_data(setup::Dict, path::AbstractString, inputs_load::Dict)
 
 Function for reading input parameters related to electricity load (demand)
 """
-function load_load_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_load::Dict)
+function load_load_data(setup::Dict, path::AbstractString, inputs_load::Dict)
 
 	# Load related inputs
 	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
 	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) # Use Time Domain Reduced data for GenX
-		load_in = DataFrame(CSV.File(string(joinpath(data_directory,"Load_data.csv")), header=true), copycols=true)
+		load_in = DataFrame(CSV.File(joinpath(data_directory,"Load_data.csv"), header=true), copycols=true)
 	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
-		load_in = DataFrame(CSV.File(string(path,sep,"Load_data.csv"), header=true), copycols=true)
+		load_in = DataFrame(CSV.File(joinpath(path,"Load_data.csv"), header=true), copycols=true)
 	end
 
 

--- a/src/load_inputs/load_minimum_capacity_requirement.jl
+++ b/src/load_inputs/load_minimum_capacity_requirement.jl
@@ -15,13 +15,12 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_minimum_capacity_requirement(path::AbstractString,sep::AbstractString, inputs::Dict, setup::Dict)
+	load_minimum_capacity_requirement(path::AbstractString, inputs::Dict, setup::Dict)
 
 Function for reading input parameters related to mimimum capacity requirement constraints (e.g. technology specific deployment mandates)
 """
-function load_minimum_capacity_requirement(path::AbstractString,sep::AbstractString, inputs::Dict, setup::Dict)
-	#MinCapReq = CSV.read(string(path,sep,"Minimum_capacity_requirement.csv"), header=true)
-	MinCapReq = DataFrame(CSV.File(string(path, sep,"Minimum_capacity_requirement.csv"), header=true), copycols=true)
+function load_minimum_capacity_requirement(path::AbstractString, inputs::Dict, setup::Dict)
+	MinCapReq = DataFrame(CSV.File(joinpath(path, "Minimum_capacity_requirement.csv"), header=true), copycols=true)
 	NumberOfMinCapReqs = size(collect(skipmissing(MinCapReq[!,:MinCapReqConstraint])),1)
 	inputs["NumberOfMinCapReqs"] = NumberOfMinCapReqs
 	inputs["MinCapReq"] = MinCapReq[!,:Min_MW]

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -15,15 +15,15 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-    load_network_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_nw::Dict)
+    load_network_data(setup::Dict, path::AbstractString, inputs_nw::Dict)
 
 Function for reading input parameters related to the electricity transmission network
 """
 #DEV NOTE:  add DC power flow related parameter inputs in a subsequent commit
-function load_network_data(setup::Dict, path::AbstractString, sep::AbstractString, inputs_nw::Dict)
+function load_network_data(setup::Dict, path::AbstractString, inputs_nw::Dict)
 
     # Network zones inputs and Network topology inputs
-    network_var = DataFrame(CSV.File(string(path,sep,"Network.csv"), header=true), copycols=true)
+    network_var = DataFrame(CSV.File(joinpath(path,"Network.csv"), header=true), copycols=true)
 
     # Number of zones in the network
     inputs_nw["Z"] = size(findall(s -> (startswith(s, "z")) & (tryparse(Float64, s[2:end]) != nothing), names(network_var)),1)

--- a/src/load_inputs/load_period_map.jl
+++ b/src/load_inputs/load_period_map.jl
@@ -15,16 +15,16 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_period_map(setup::Dict,path::AbstractString,sep::AbstractString, inputs::Dict)
+	load_period_map(setup::Dict,path::AbstractString, inputs::Dict)
 
 Function for reading input parameters related to mapping of representative time periods to full chronological time series
 """
-function load_period_map(setup::Dict,path::AbstractString,sep::AbstractString, inputs::Dict)
+function load_period_map(setup::Dict,path::AbstractString, inputs::Dict)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
 	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Period_map.csv"))  # Use Time Domain Reduced data for GenX
-		inputs["Period_Map"] = DataFrame(CSV.File(string(joinpath(data_directory,"Period_map.csv")), header=true), copycols=true)
+		inputs["Period_Map"] = DataFrame(CSV.File(joinpath(data_directory,"Period_map.csv"), header=true), copycols=true)
 	else
-		inputs["Period_Map"] = DataFrame(CSV.File(string(path,sep,"Period_map.csv"), header=true), copycols=true)
+		inputs["Period_Map"] = DataFrame(CSV.File(joinpath(path,"Period_map.csv"), header=true), copycols=true)
 	end
 
 	println("Period_map.csv Successfully Read!")

--- a/src/load_inputs/load_reserves.jl
+++ b/src/load_inputs/load_reserves.jl
@@ -15,13 +15,13 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_reserves(setup::Dict,path::AbstractString,sep::AbstractString, inputs_res::Dict)
+	load_reserves(setup::Dict,path::AbstractString, inputs_res::Dict)
 
 Function for reading input parameters related to frequency regulation and operating reserve requirements
 """
-function load_reserves(setup::Dict,path::AbstractString,sep::AbstractString, inputs_res::Dict)
+function load_reserves(setup::Dict,path::AbstractString, inputs_res::Dict)
 	##Reserve inputs
-	res_in = DataFrame(CSV.File(string(path,sep,"Reserves.csv"), header=true), copycols=true)
+	res_in = DataFrame(CSV.File(joinpath(path, "Reserves.csv"), header=true), copycols=true)
 
 	# Regulation requirement as a percent of hourly load; here load is the total across all model zones
 	inputs_res["pReg_Req_Load"] = convert(Float64, res_in[!,:Reg_Req_Percent_Load][1])


### PR DESCRIPTION
This simplifies the code by removing an argument 'sep' from the loading scripts. Let julia do
its job by figuring out how to join paths.

Also remove replaced/commented-out code (CSV.read calls that have been supplanted)