### PR TITLE
Remove unused code requiring CapRes_* cols

### DIFF
--- a/src/load_inputs/load_cap_reserve_margin.jl
+++ b/src/load_inputs/load_cap_reserve_margin.jl
@@ -48,11 +48,6 @@ function load_cap_reserve_margin_trans(setup::Dict, path::AbstractString, sep::A
 
 	res = inputs_crm["NCapacityReserveMargin"]
 
-	first_col_trans = findall(s -> s == "CapRes_1", names(network_var))[1]
-	last_col_trans = findall(s -> s == "CapRes_$res", names(network_var))[1]
-	dfTransCapRes = network_var[:,first_col_trans:last_col_trans]
-	inputs_crm["dfTransCapRes"] = Matrix{Float64}(dfTransCapRes[completecases(dfTransCapRes),:])
-
 	first_col_trans_derate = findall(s -> s == "DerateCapRes_1", names(network_var))[1]
 	last_col_trans_derate = findall(s -> s == "DerateCapRes_$res", names(network_var))[1]
 	dfDerateTransCapRes = network_var[:,first_col_trans_derate:last_col_trans_derate]


### PR DESCRIPTION
The `dfTransCapRes` matrix created using CapRes_ columns isn't used anywhere in GenX. Remove those lines so the CapRes_ cols aren't required in Network.csv.