### PR TITLE
Remove references to LongDurationStorage key

### DIFF
--- a/Example_Systems/MethodofMorrisExample/OneZone/Settings/genx_settings.yml
+++ b/Example_Systems/MethodofMorrisExample/OneZone/Settings/genx_settings.yml
@@ -13,7 +13,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 0 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/RealSystemExample/ISONE_Singlezone/Settings/genx_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Singlezone/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 1 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 0 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Settings/genx_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 0 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 0 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 0 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Results/genx_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Results/genx_settings.yml
@@ -18,7 +18,6 @@ Trans_Loss_Segments: 1
 CapacityReserveMargin: 0
 ModelingtoGenerateAlternativeSlack: 0.1
 Solver: "Gurobi"
-LongDurationStorage: 0
 Reserves: 0
 StorageLosses: 1
 OperationWrapping: 1

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Settings/genx_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/SmallNewEngland/OneZone/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 0 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/SmallNewEngland/OneZone_3VREBin/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone_3VREBin/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 1 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/SmallNewEngland/OneZone_MultiStage/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone_MultiStage/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/SmallNewEngland/ThreeZones/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/genx_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/genx_settings.yml
@@ -14,7 +14,6 @@ ParameterScale: 1 # Turn on parameter scaling wherein load, capacity and power v
 WriteShadowPrices: 0 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
 OperationWrapping: 1 # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
-LongDurationStorage: 0 # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
 TimeDomainReductionFolder: "TDR_Results" # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 ModelingToGenerateAlternatives: 0 # Modeling to generate alternatives; 0 = not active; 1 = active. Note: produces a single solution as output

--- a/docs/src/data_documentation.md
+++ b/docs/src/data_documentation.md
@@ -12,9 +12,6 @@ Model settings parameters are specified in a `GenX_Settings.yml` file which shou
 |OperationWrapping | Select temporal resolution for operations constraints.|
 ||0 = Models intra-annual operations as a single contiguous period. Inter-temporal constraint are defined based on linking first time step with the last time step of the year.|
 ||1 = Models intra-annual operations using multiple representative periods. Inter-temporal constraints are defined based on linking first time step with the last time step of each representative period.|
-|LongDurationStorage | Select whether inter-period energy exchange allowed for storage technologies.|
-||0= inter-period energy exchange not allowed.|
-||1 = inter-period energy exchange allowed.|
 |TimeDomainReduction | 1 = Use time domain reduced inputs available in the folder with the name defined by settings parameter TimeDomainReduction Folder. If such a folder does not exist or it is empty, time domain reduction will reduce the input data and save the results in the folder with this name. These reduced inputs are based on full input data provided by user in `Load_data.csv`, `Generators_variability.csv`, and `Fuels_data.csv`.|
 ||0 = Use full input data as provided.|
 |TimeDomainReductionFolder | Name of the folder where time domain reduced input data is accessed and stored.|

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -53,8 +53,6 @@ function configure_settings(settings_path::String)
     set_default_if_absent!(settings, "UCommit", 0)
     # Sets temporal resolution of the model; 0 = single period to represent the full year, with first-last time step linked; 1 = multiple representative periods
     set_default_if_absent!(settings, "OperationWrapping", 0)
-    # Inter-period energy exchange for storage technologies; 0 = not active; 1 = active systemwide
-    set_default_if_absent!(settings, "LongDurationStorage", 0)
     # Directory name where results from time domain reduction will be saved. If results already exist here, these will be used without running time domain reduction script again.
     set_default_if_absent!(settings, "TimeDomainReductionFolder", "TDR_Results")
     # Time domain reduce (i.e. cluster) inputs based on Load_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)

--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -46,11 +46,9 @@ function load_generators_data(setup::Dict, path::AbstractString, sep::AbstractSt
 	inputs_gen["STOR_ALL"] = union(inputs_gen["STOR_SYMMETRIC"],inputs_gen["STOR_ASYMMETRIC"])
 
 	# Set of storage resources with long duration storage capabilitites
-	#if setup["LongDurationStorage"] == 1
-		inputs_gen["STOR_HYDRO_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.HYDRO.==1),:R_ID]
-		inputs_gen["STOR_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.STOR.==1),:R_ID]
-		inputs_gen["STOR_SHORT_DURATION"] = gen_in[(gen_in.LDS.==0) .& (gen_in.STOR.==1),:R_ID]
-	#end
+	inputs_gen["STOR_HYDRO_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.HYDRO.==1),:R_ID]
+	inputs_gen["STOR_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.STOR.==1),:R_ID]
+	inputs_gen["STOR_SHORT_DURATION"] = gen_in[(gen_in.LDS.==0) .& (gen_in.STOR.==1),:R_ID]
 
 	# Set of all reservoir hydro resources
 	inputs_gen["HYDRO_RES"] = gen_in[(gen_in[!,:HYDRO].==1),:R_ID]

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -175,9 +175,9 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	if !isempty(inputs["STOR_ALL"])
 ##dev_ddp
 		if setup["MultiStage"] > 0 
-			EP = storage_multi_stage(EP, inputs, setup["Reserves"], setup["OperationWrapping"], setup["LongDurationStorage"], setup["MultiStageSettingsDict"])
+			EP = storage_multi_stage(EP, inputs, setup["Reserves"], setup["OperationWrapping"], setup["MultiStageSettingsDict"])
 		else
-			EP = storage(EP, inputs, setup["Reserves"], setup["OperationWrapping"], setup["LongDurationStorage"], setup["EnergyShareRequirement"], setup["CapacityReserveMargin"], setup["StorageLosses"])
+			EP = storage(EP, inputs, setup["Reserves"], setup["OperationWrapping"], setup["EnergyShareRequirement"], setup["CapacityReserveMargin"], setup["StorageLosses"])
 		end
 		
 ##Dev

--- a/src/model/resources/storage/storage.jl
+++ b/src/model/resources/storage/storage.jl
@@ -15,7 +15,7 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	storage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, LongDurationStorage::Int, EnergyShareRequirement::Int, CapacityReserveMargin::Int)
+	storage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, EnergyShareRequirement::Int, CapacityReserveMargin::Int)
 A wide range of energy storage devices (all $o \in \mathcal{O}$) can be modeled in GenX, using one of two generic storage formulations: (1) storage technologies with symmetric charge and discharge capacity (all $o \in \mathcal{O}^{sym}$), such as Lithium-ion batteries and most other electrochemical storage devices that use the same components for both charge and discharge; and (2) storage technologies that employ distinct and potentially asymmetric charge and discharge capacities (all $o \in \mathcal{O}^{asym}$), such as most thermal storage technologies or hydrogen electrolysis/storage/fuel cell or combustion turbine systems.
 **Storage with symmetric charge and discharge capacity**
 For storage technologies with symmetric charge and discharge capacity (all $o \in \mathcal{O}^{sym}$), charge rate, $\Pi_{o,z,t}$, is constrained by the total installed power capacity, $\Omega_{o,z}$. Since storage resources generally represent a `cluster' of multiple similar storage devices of the same type/cost in the same zone, GenX permits storage resources to simultaneously charge and discharge (as some units could be charging while others discharge), with the simultaenous sum of charge, $\Pi_{o,z,t}$, and discharge, $\Theta_{o,z,t}$, also limited by the total installed power capacity, $\Delta^{total}_{o,z}$. These two constraints are as follows:
@@ -60,7 +60,7 @@ The following two constraints track the state of charge of the storage resources
 	&  \Gamma_{o,z,t} =\Gamma_{o,z,t+\tau^{period}-1} - \frac{1}{\eta_{o,z}^{discharge}}\Theta_{o,z,t} + \eta_{o,z}^{charge}\Pi_{o,z,t} - \eta_{o,z}^{loss}\Gamma_{o,z,t+\tau^{period}-1}  \quad \forall o \in \mathcal{O}, z \in \mathcal{Z}, t \in \mathcal{T}^{start}
 \end{aligned}
 ```
-When modeling the entire year as a single chronological period with total number of time steps of $\tau^{period}$, storage inventory in the first time step is linked to storage inventory at the last time step of the period representing the year. Alternatively, when modeling the entire year with multiple representative periods, this constraint relates storage inventory in the first timestep of the representative period with the inventory at the last time step of the representative period, where each representative period is made of $\tau^{period}$ time steps. In this implementation, energy exchange between representative periods is not permitted. When modeling representative time periods, GenX enables modeling of long duration energy storage which tracks state of charge between representative periods enable energy to be moved throughout the year. If ```LongDurationStorage=1``` and ```OperationWrapping=1```, this function calls ```long_duration_storage()``` in ```long_duration_storage.jl``` to enable this feature.
+When modeling the entire year as a single chronological period with total number of time steps of $\tau^{period}$, storage inventory in the first time step is linked to storage inventory at the last time step of the period representing the year. Alternatively, when modeling the entire year with multiple representative periods, this constraint relates storage inventory in the first timestep of the representative period with the inventory at the last time step of the representative period, where each representative period is made of $\tau^{period}$ time steps. In this implementation, energy exchange between representative periods is not permitted. When modeling representative time periods, GenX enables modeling of long duration energy storage which tracks state of charge between representative periods enable energy to be moved throughout the year. If ```OperationWrapping=1``` and ```LDS``` has been enabled for resources in ```Generators.csv```, this function calls ```long_duration_storage()``` in ```long_duration_storage.jl``` to enable this feature.
 The next constraint limits the volume of energy stored at any time, $\Gamma_{o,z,t}$, to be less than the installed energy storage capacity, $\Delta^{total, energy}_{o,z}$. Finally, the maximum discharge rate for storage resources, $\Pi_{o,z,t}$, is constrained to be less than the discharge power capacity, $\Omega_{o,z,t}$ or the state of charge at the end of the last period, $\Gamma_{o,z,t-1}$, whichever is lessor.
 ```math
 \begin{aligned}
@@ -108,7 +108,7 @@ Finally, the constraints on maximum discharge rate are replaced by the following
 ```
 The above reserve related constraints are established by ```storage_all_reserves()``` in ```storage_all.jl```
 """
-function storage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, LongDurationStorage::Int, EnergyShareRequirement::Int, CapacityReserveMargin::Int, StorageLosses::Int)
+function storage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, EnergyShareRequirement::Int, CapacityReserveMargin::Int, StorageLosses::Int)
 
 	println("Storage Resources Module")
 	dfGen = inputs["dfGen"]
@@ -120,7 +120,7 @@ function storage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int,
 		EP = investment_energy(EP, inputs)
 		EP = storage_all(EP, inputs, Reserves, OperationWrapping)
 
-		# Include LongDurationStorage only when modeling representative periods and long-duration storage
+		# Include Long Duration Storage only when modeling representative periods and long-duration storage
 		if OperationWrapping == 1 && !isempty(inputs["STOR_LONG_DURATION"])
 			EP = long_duration_storage(EP, inputs)
 		end

--- a/src/multi_stage/model_multi_stage/storage_multi_stage.jl
+++ b/src/multi_stage/model_multi_stage/storage_multi_stage.jl
@@ -15,11 +15,11 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	storage_multi_stage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, LongDurationStorage::Int, MultiStageSettingsDict::Dict)
+	storage_multi_stage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, MultiStageSettingsDict::Dict)
 
 This function is identical to storage(), except calls multi-stage investment energy and charge methods.
 """
-function storage_multi_stage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, LongDurationStorage::Int, MultiStageSettingsDict::Dict)
+function storage_multi_stage(EP::Model, inputs::Dict, Reserves::Int, OperationWrapping::Int, MultiStageSettingsDict::Dict)
 
 	println("Storage Resources multi-stage Module")
 
@@ -27,11 +27,10 @@ function storage_multi_stage(EP::Model, inputs::Dict, Reserves::Int, OperationWr
 
 	if !isempty(inputs["STOR_ALL"])
 		EP = investment_energy_multi_stage(EP, inputs, MultiStageSettingsDict)
-		#EP = storage_all(EP, inputs, Reserves, OperationWrapping, LongDurationStorage) # LDS parameter removed 12102021 by jfmorris
 		EP = storage_all(EP, inputs, Reserves, OperationWrapping)
 
-		# Include LongDurationStorage only when modeling representative periods and long-duration storage
-		if OperationWrapping == 1 && LongDurationStorage == 1
+		# Include Long Duration Storage only when modeling representative periods and long-duration storage
+		if OperationWrapping == 1 && !isempty(inputs["STOR_LONG_DURATION"])
 			EP = long_duration_storage(EP, inputs)
 		end
 	end


### PR DESCRIPTION
Settings files may not include the LongDurationStorage key anymore because it is obsolete.

This prevents errors when the obsolete key is not included in settings.