### PR TITLE
A few improvements to the morris script

### DIFF
--- a/src/additional_tools/method_of_morris.jl
+++ b/src/additional_tools/method_of_morris.jl
@@ -189,9 +189,19 @@ function my_gsa(f, p_steps, num_trajectory, total_num_trajectory, p_range::Abstr
     #println(effects)
     MorrisResult(reduce(hcat, means),reduce(hcat, means_star),reduce(hcat, variances),effects)
 end
+
+function set_random_seed!(setup::Dict)
+    key = "MethodofMorrisRandomSeed"
+    if haskey(setup, key)
+        seed = setup[key]
+        Random.seed!(seed)
+    end
+end
+
 function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outpath::AbstractString, OPTIMIZER)
 
     # Reading the input parameters
+    set_random_seed!(setup)
     Morris_range = DataFrame(CSV.File(joinpath(path, "Method_of_morris_range.csv"), header=true), copycols=true)
     groups = Morris_range[!,:Group]
     p_steps = Morris_range[!,:p_steps]
@@ -240,7 +250,7 @@ function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outp
             for column in uncertain_columns
                 entries_for_param = Morris_range[!, :Parameter].==column
                 sel = entries_for_file .& entries_for_param
-                index = Morris_range[sel,:ID]
+                index = (1:length(sel))[sel]
                 my_df[!,Symbol(column)] = sigma[first(index):last(index)]
             end
         end


### PR DESCRIPTION
Here's a few improvements to the Morris script. I made them in an attempt to better understand the code in preparation for my own improvements.

Improvements include

* deduplicating code by using a `Dict` relating the file that a column is in and the name of the dataframe.
* breaking up long repeated lines into shorter expressions to increase readability
* making a O(n^2) algorithm more like O(n) (though this is admittedly not performance critical)
* substituting `joinpath` for custom directory forming
* replace a for loop with builtin `cumsum` for readability
* replace `eltype(x)[]` with `similar(x, 0)` which I think is better semantically?
* replace `df[!, :col][1]` with `df[1, :col]` for brevity and less syntax

I tested before-and-after these two commits against the FLECCS example with Morris enabled and the results were identical. (I subbed in a `Random.seed!(1)` to ensure the results are identical.)