### PR TITLE
Resolving first-stage-only network expansion issue in multi-stage GenX

### DIFF
--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p1/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p1/Network.csv
@@ -1,4 +1,4 @@
 ﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
+MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
+CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
 ME,z3,,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p2/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p2/Network.csv
@@ -1,4 +1,4 @@
 ﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,8850,0.062,30
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,6000,0.062,30
+MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
+CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
 ME,z3,,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p3/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p3/Network.csv
@@ -1,4 +1,4 @@
 ﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,11800,0.062,30
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,8000,0.062,30
+MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
+CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
 ME,z3,,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/multi_stage_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/multi_stage_settings.yml
@@ -2,4 +2,4 @@ NumStages: 3 # Number of model investment planning stages
 StageLengths: [10,10,10] # Length of each model stage (years)
 WACC: 0.045 # Weighted average cost of capital
 ConvergenceTolerance: 0.01 # Relative optimality gap used for convergence
-Myopic: 1 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming
+Myopic: 0 # If using multi-stage GenX, 1 = myopic, 0 = dual dynamic programming

--- a/src/multi_stage/load_inputs_multi_stage/configure_multi_stage_inputs.jl
+++ b/src/multi_stage/load_inputs_multi_stage/configure_multi_stage_inputs.jl
@@ -127,17 +127,11 @@ function configure_multi_stage_inputs(inputs_d::Dict, settings_d::Dict, NetworkE
 		# Scale max_allowed_reinforcement to allow for possibility of deploying maximum reinforcement in each investment stage
 		inputs_d["pTrans_Max_Possible"] = inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"]
 
-        # Network lines and zones that are expandable have greater maximum possible line flow than that of the previous stage
-		if cur_stage > 1
-			inputs_d["EXPANSION_LINES"] = findall(inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"] .> inputs_d["pLine_Max_Flow_Possible_MW_p$(cur_stage-1)"])
-        	inputs_d["NO_EXPANSION_LINES"] = findall(inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"] .<= inputs_d["pLine_Max_Flow_Possible_MW_p$(cur_stage-1)"])
-		else
-			inputs_d["EXPANSION_LINES"] = findall(inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"] .> inputs_d["pTrans_Max"])
-			inputs_d["NO_EXPANSION_LINES"] = findall(inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"] .<= inputs_d["pTrans_Max"])
-
+        # Network lines and zones that are expandable have greater maximum possible line flow than the available capacity of the previous stage as well as available line reinforcement
+		inputs_d["EXPANSION_LINES"] = findall((inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"] .> inputs_d["pTrans_Max"]) .& (inputs_d["pMax_Line_Reinforcement"] .> 0))
+		inputs_d["NO_EXPANSION_LINES"] = findall((inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"] .<= inputs_d["pTrans_Max"]) .| (inputs_d["pMax_Line_Reinforcement"] .<= 0))
 			# To-Do: Error Handling
 			# 1.) Enforce that pLine_Max_Flow_Possible_MW_p1 be equal to (for transmission expansion to be disalowed) or greater (to allow transmission expansion) than pTrans_Max in Inputs/Inputs_p1
-		end
     end
 
     return inputs_d

--- a/src/multi_stage/model_multi_stage/transmission_multi_stage.jl
+++ b/src/multi_stage/model_multi_stage/transmission_multi_stage.jl
@@ -165,8 +165,11 @@ function transmission_multi_stage(EP::Model, inputs::Dict, UCommit::Int, Network
 	# If network expansion is used:
 	if NetworkExpansion == 1
 		# Transmission network related power flow and capacity constraints
-		# Constrain maximum line capacity reinforcement for lines eligible for expansion
-		@constraint(EP, cMaxLineReinforcement[l in EXPANSION_LINES], eAvail_Trans_Cap[l] <= inputs["pTrans_Max_Possible"][l])
+		# Constrain maximum possible flow for lines eligible for expansion regardless of previous expansions
+		@constraint(EP, cMaxFlowPossible[l in EXPANSION_LINES], eAvail_Trans_Cap[l] <= inputs["pTrans_Max_Possible"][l])
+
+		# Constrain maximum single-stage line capacity reinforcement for lines eligible for expansion
+		@constraint(EP, cMaxLineReinforcement[l in EXPANSION_LINES], vNEW_TRANS_CAP[l] <= inputs["pMax_Line_Reinforcement"][l])
 	end
 	#END network expansion contraints
 


### PR DESCRIPTION
These changes resolve two bugs with regard to network expansion in multi-stage GenX. First, network expansion in any given stage was limited only by the cumulative maximum flow (Line_Max_Flow_Possible_MW) and not also the single-stage maximum reinforcement (Line_Max_Reinforcement_MW) as had been intended. Second, the sets of expandable and non-expandable lines were defined improperly for stages after the first leading to all subsequent stages being denied network expansion. This pull request resolves these two issues by (1) defining a single-stage maximum reinforcement constraint in transmission_multi_stage.jl just like that in transmission.jl for single-stage GenX, and (2) redefining the EXPANSION_LINES set in configure_multi_stage_inputs.jl to reflect the inputs as intended. 
For the sake of testing, I also changed the default Line_Max_Flow_Possible_MW in the SmallNewEngland/ThreeZones_MultiStage example to be a constant value throughout the three stages which is greater than one full stage of expansion but less than three full stages. I also changed this example's multi-stage default to be DDP, rather than myopic.