### PR TITLE
Call write_costs exactly once

### DIFF
--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -67,13 +67,12 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 	end
 
 	write_status(path, sep, inputs, setup, EP)
-	write_costs(path, sep, inputs, setup, EP)
+	elapsed_time_costs = @elapsed write_costs(path, sep, inputs, setup, EP)
+	println("Time elapsed for writing costs is")
+	println(elapsed_time_costs)
 	if setup["MultiStage"] == 1
 		dfCap = write_capacity_multi_stage(path, sep, inputs, setup, EP)
 	else
-    elapsed_time_costs = @elapsed write_costs(path, sep, inputs, setup, EP)
-	  println("Time elapsed for writing costs is")
-	  println(elapsed_time_costs)
 		dfCap = write_capacity(path, sep, inputs, setup, EP)
 	end
 	dfPower = write_power(path, sep, inputs, setup, EP)


### PR DESCRIPTION
A simple rearrangement ensures that `write_costs` is called only once. This addresses #135 .