### PR TITLE
Annualizing costs in myopic multi-stage GenX

### DIFF
--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Run_multi_stage.jl
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Run_multi_stage.jl
@@ -106,4 +106,4 @@ for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
 end
 
 # Step 5) Write DDP summary outputs
-write_multi_stage_outputs(mystats_d, outpath, mysetup)
+write_multi_stage_outputs(mystats_d, outpath, mysetup, inputs_dict)

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -98,7 +98,7 @@ function run_ddp(models_d::Dict, setup::Dict, inputs_d::Dict)
 
     # Step a.i) Initialize cost-to-go function for t = 1:num_stages
     for t in 1:num_stages
-        models_d[t] = initialize_cost_to_go(settings_d, models_d[t])
+        models_d[t] = initialize_cost_to_go(settings_d, models_d[t], inputs_d[t])
     end
 
     # Step a.ii) Set objective upper bound
@@ -248,7 +248,7 @@ inputs:
   * outpath – String which represents the path to the Results directory.
   * settings\_d - Dictionary containing settings configured in the GenX settings genx_settings.yml file as well as the multi-stage settings file multi\_stage\_settings.yml.
 """
-function write_multi_stage_outputs(stats_d::Dict, outpath::String, settings_d::Dict)
+function write_multi_stage_outputs(stats_d::Dict, outpath::String, settings_d::Dict, inputs_dict::Dict)
 
 	if Sys.isunix()
 		sep = "/"
@@ -264,7 +264,7 @@ function write_multi_stage_outputs(stats_d::Dict, outpath::String, settings_d::D
     #write_capacities_charge(outpath, sep, multi_stage_settings_d)
     #write_capacities_energy(outpath, sep, multi_stage_settings_d)
     #write_network_expansion(outpath, sep, multi_stage_settings_d)
-    write_costs(outpath, sep, multi_stage_settings_d)
+    write_costs(outpath, sep, multi_stage_settings_d, inputs_dict)
     write_stats(outpath, sep, stats_d)
 	write_settings(outpath, sep, settings_d)
 
@@ -328,7 +328,7 @@ inputs:
   * sep – String which represents the file directory separator character.
   * settings\_d - Dictionary containing settings dictionary configured in the multi-stage settings file multi\_stage\_settings.yml.
 """
-function write_costs(outpath::String, sep::String, settings_d::Dict)
+function write_costs(outpath::String, sep::String, settings_d::Dict, inputs_dict::Dict)
 
 	num_stages = settings_d["NumStages"] # Total number of DDP stages
 	wacc = settings_d["WACC"] # Interest Rate and also the discount rate unless specified other wise
@@ -341,7 +341,8 @@ function write_costs(outpath::String, sep::String, settings_d::Dict)
         costs_d[p] = DataFrame(CSV.File(string(cur_path,sep,"costs.csv"), header=true), copycols=true)
     end
 
-	OPEXMULTS = [ sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_lens[j])]) for j in 1:num_stages] # Stage-wise OPEX multipliers to count multiple years between two model stages
+	OPEXMULTS = [ inputs_dict[j]["OPEXMULT"] for j in 1:num_stages ] # Stage-wise OPEX multipliers to count multiple years between two model stages
+
     # Set first column of DataFrame as resource names from the first stage
     df_costs = DataFrame(Costs = costs_d[1][!,:Costs])
 
@@ -652,22 +653,22 @@ inputs:
 
 returns: JuMP model with updated objective function.
 """
-function initialize_cost_to_go(settings_d::Dict, EP::Model)
+function initialize_cost_to_go(settings_d::Dict, EP::Model, inputs::Dict)
 
 	cur_stage = settings_d["CurStage"] # Current DDP Investment Planning Stage
 	stage_len = settings_d["StageLengths"][cur_stage]
 	wacc = settings_d["WACC"] # Interest Rate  and also the discount rate unless specified other wise
 	myopic = settings_d["Myopic"] == 1 # 1 if myopic (only one forward pass), 0 if full DDP
-
-	DF = 1/(1+wacc)^(stage_len*(cur_stage-1))  # Discount factor applied all to costs in each stage
-	OPEXMULT = sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)]) # OPEX multiplier to count multiple years between two model stages
+	OPEXMULT = inputs["OPEXMULT"] # OPEX multiplier to count multiple years between two model stages, set in configure_multi_stage_inputs.jl
 
 	# Overwrite the objective function to include the cost-to-go variable (not in myopic case)
 	# Multiply discount factor to all terms except the alpha term or the cost-to-go function
 	# All OPEX terms get an additional adjustment factor
 	if myopic
-		@objective(EP, Min, DF*OPEXMULT*EP[:eObj])
+		### No discount factor or OPEX multiplier applied in myopic case as costs are left annualized.
+		@objective(EP, Min, EP[:eObj])
 	else
+		DF = 1/(1+wacc)^(stage_len*(cur_stage-1))  # Discount factor applied all to costs in each stage ###
 		# Initialize the cost-to-go variable
 	    @variable(EP, vALPHA >= 0);
 		@objective(EP, Min, DF*OPEXMULT*EP[:eObj] + vALPHA)

--- a/src/multi_stage/load_inputs_multi_stage/configure_multi_stage_inputs.jl
+++ b/src/multi_stage/load_inputs_multi_stage/configure_multi_stage_inputs.jl
@@ -94,20 +94,23 @@ function configure_multi_stage_inputs(inputs_d::Dict, settings_d::Dict, NetworkE
 	wacc = settings_d["WACC"] # Interest Rate  and also the discount rate unless specified other wise
 	myopic = settings_d["Myopic"] == 1 # 1 if myopic (only one forward pass), 0 if full DDP
 
-	# 1. Convert annualized investment costs incured within the model horizon into overnight capital costs
-	# NOTE: Although the "yr" suffix is still in use in these parameter names, they no longer represent annualized costs but rather truncated overnight capital costs
-	inputs_d["dfGen"][!,:Inv_Cost_per_MWyr] = compute_overnight_capital_cost(settings_d,dfGen[!,:Inv_Cost_per_MWyr],dfGenMultiStage[!,:Capital_Recovery_Period],dfGen[!,:WACC])
-	inputs_d["dfGen"][!,:Inv_Cost_per_MWhyr] = compute_overnight_capital_cost(settings_d,dfGen[!,:Inv_Cost_per_MWhyr],dfGenMultiStage[!,:Capital_Recovery_Period],dfGen[!,:WACC])
-	inputs_d["dfGen"][!,:Inv_Cost_Charge_per_MWyr] = compute_overnight_capital_cost(settings_d,dfGen[!,:Inv_Cost_Charge_per_MWyr],dfGenMultiStage[!,:Capital_Recovery_Period],dfGen[!,:WACC])
+	# Define OPEXMULT here, include in inputs_dict[t] for use in dual_dynamic_programming.jl, transmission_multi_stage.jl, and investment_multi_stage.jl
+	OPEXMULT = myopic ? 1 : sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)])
+	inputs_d["OPEXMULT"] = OPEXMULT
 
-	# 2. Update fixed O&M costs to account for the possibility of more than 1 year between two model stages
-	OPEXMULT = sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)]) # OPEX multiplier to count multiple years between two model stages
+	if !myopic ### Leave myopic costs in annualized form and do not scale OPEX costs
+		# 1. Convert annualized investment costs incured within the model horizon into overnight capital costs
+		# NOTE: Although the "yr" suffix is still in use in these parameter names, they no longer represent annualized costs but rather truncated overnight capital costs
+		inputs_d["dfGen"][!,:Inv_Cost_per_MWyr] = compute_overnight_capital_cost(settings_d,dfGen[!,:Inv_Cost_per_MWyr],dfGenMultiStage[!,:Capital_Recovery_Period],dfGen[!,:WACC])
+		inputs_d["dfGen"][!,:Inv_Cost_per_MWhyr] = compute_overnight_capital_cost(settings_d,dfGen[!,:Inv_Cost_per_MWhyr],dfGenMultiStage[!,:Capital_Recovery_Period],dfGen[!,:WACC])
+		inputs_d["dfGen"][!,:Inv_Cost_Charge_per_MWyr] = compute_overnight_capital_cost(settings_d,dfGen[!,:Inv_Cost_Charge_per_MWyr],dfGenMultiStage[!,:Capital_Recovery_Period],dfGen[!,:WACC])
 
-	# Update fixed O&M costs
-	# NOTE: Although the "yr" suffix is still in use in these parameter names, they now represent total costs incured in each stage, which may be multiple years
-	inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWyr] = OPEXMULT.*inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWyr]
-	inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWhyr] = OPEXMULT.*inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWhyr]
-	inputs_d["dfGen"][!,:Fixed_OM_Cost_charge_per_MWyr] = OPEXMULT.*inputs_d["dfGen"][!,:Fixed_OM_Cost_Charge_per_MWyr]
+		# 2. Update fixed O&M costs to account for the possibility of more than 1 year between two model stages
+		# NOTE: Although the "yr" suffix is still in use in these parameter names, they now represent total costs incured in each stage, which may be multiple years
+		inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWyr] = OPEXMULT.*inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWyr]
+		inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWhyr] = OPEXMULT.*inputs_d["dfGen"][!,:Fixed_OM_Cost_per_MWhyr]
+		inputs_d["dfGen"][!,:Fixed_OM_Cost_charge_per_MWyr] = OPEXMULT.*inputs_d["dfGen"][!,:Fixed_OM_Cost_Charge_per_MWyr]
+	end
 
     # Set of all resources eligible for capacity retirements
 	inputs_d["RET_CAP"] = intersect(dfGen[dfGen.New_Build.!=-1,:R_ID])
@@ -121,8 +124,10 @@ function configure_multi_stage_inputs(inputs_d::Dict, settings_d::Dict, NetworkE
 
 		dfNetworkMultiStage = inputs_d["dfNetworkMultiStage"]
 
-		# 1. Convert annualized tramsmission investment costs incured within the model horizon into overnight capital costs
-		inputs_d["pC_Line_Reinforcement"] = compute_overnight_capital_cost(settings_d,inputs_d["pC_Line_Reinforcement"],dfNetworkMultiStage[!,:Capital_Recovery_Period], inputs_d["transmission_WACC"])
+		if !myopic ### Leave myopic costs in annualized form
+			# 1. Convert annualized tramsmission investment costs incured within the model horizon into overnight capital costs
+			inputs_d["pC_Line_Reinforcement"] = compute_overnight_capital_cost(settings_d,inputs_d["pC_Line_Reinforcement"],dfNetworkMultiStage[!,:Capital_Recovery_Period], inputs_d["transmission_WACC"])
+		end
 
 		# Scale max_allowed_reinforcement to allow for possibility of deploying maximum reinforcement in each investment stage
 		inputs_d["pTrans_Max_Possible"] = inputs_d["pLine_Max_Flow_Possible_MW_p$cur_stage"]

--- a/src/multi_stage/model_multi_stage/investment_multi_stage.jl
+++ b/src/multi_stage/model_multi_stage/investment_multi_stage.jl
@@ -150,11 +150,9 @@ function investment_discharge_multi_stage(EP::Model, inputs::Dict, multi_stage_s
 
 	# Add term to objective function expression
 	# DDP - OPEX multiplier to count multiple years between two model stages
-	OPEXMULT = sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)])
-
 	# We divide by OPEXMULT since we are going to multiply the entire objective function by this term later,
 	# and we have already accounted for multiple years between stages for fixed costs.
-	EP[:eObj] += (1/OPEXMULT)*eTotalCFix
+	EP[:eObj] += (1/inputs["OPEXMULT"])*eTotalCFix
 
 	## DDP - Endogenous Retirements ##
 
@@ -301,10 +299,9 @@ function investment_charge_multi_stage(EP::Model, inputs::Dict, multi_stage_sett
 
 	# Add term to objective function expression
 	# DDP - OPEX multiplier to count multiple years between two model stages
-	OPEXMULT = sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)])
 	# We divide by OPEXMULT since we are going to multiply the entire objective function by this term later,
 	# and we have already accounted for multiple years between stages for fixed costs.
-	EP[:eObj] += (1/OPEXMULT)*eTotalCFixCharge
+	EP[:eObj] += (1/inputs["OPEXMULT"])*eTotalCFixCharge
 
 	## DDP - Endogenous Retirements ##
 
@@ -444,10 +441,9 @@ function investment_energy_multi_stage(EP::Model, inputs::Dict, multi_stage_sett
 
 	# Add term to objective function expression
 	# DDP - OPEX multiplier to count multiple years between two model stages
-	OPEXMULT = sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)])
 	# We divide by OPEXMULT since we are going to multiply the entire objective function by this term later,
 	# and we have already accounted for multiple years between stages for fixed costs.
-	EP[:eObj] += (1/OPEXMULT)*eTotalCFixEnergy
+	EP[:eObj] += (1/inputs["OPEXMULT"])*eTotalCFixEnergy
 
 	## DDP - Endogenous Retirements ##
 

--- a/src/multi_stage/model_multi_stage/transmission_multi_stage.jl
+++ b/src/multi_stage/model_multi_stage/transmission_multi_stage.jl
@@ -129,10 +129,9 @@ function transmission_multi_stage(EP::Model, inputs::Dict, UCommit::Int, Network
 		stage_len = multi_stage_settings_d["StageLengths"][cur_stage]
 
 		# DDP - OPEX multiplier to count multiple years between two model stages
-		OPEXMULT = sum([1/(1+wacc)^(i-1) for i in range(1,stop=stage_len)])
 		# We divide by OPEXMULT since we are going to multiply the entire objective function by this term later,
 		# and we have already accounted for multiple years between stages for fixed costs.
-		EP[:eObj] += (1/OPEXMULT)*eTotalCNetworkExp
+		EP[:eObj] += (1/inputs["OPEXMULT"])*eTotalCNetworkExp
 
     end
 


### PR DESCRIPTION
To annualize costs in the myopic case, we no longer overwrite the originally annualized input costs with overnight capital costs, we do not apply the discount factor DF (used to translate costs to net present costs) to the objective, and we do not apply the O&M multiplier OPEXMULT (to scale yearly O&M costs to account for the full duration between model stages). We now define OPEXMULT in one location (configure_multi_stage_inputs) in order to prevent recalculations in several different locations which might result in errors when making future changes, but this does require passing the input dictionary (which houses OPEXMULT) to the write_costs() and initialize_cost_to_go() functions where it had not been passed previously. 
