### PR TITLE
Annualize outputs for reserves and ucommit

### DIFF
--- a/src/write_outputs/reserves/write_reg.jl
+++ b/src/write_outputs/reserves/write_reg.jl
@@ -22,15 +22,15 @@ function write_reg(path::AbstractString, sep::AbstractString, inputs::Dict, setu
 	REG = inputs["REG"]
 
 	# Regulation contributions for each resource in each time step
-	dfReg = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!,:Zone], Sum = Array{Float64}(undef, G))
+	dfReg = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!,:Zone])
 	reg = zeros(G,T)
 	reg[REG, :] = value.(EP[:vREG][REG, :])
-	dfReg.Sum = sum(reg, dims=2)[:]
+	dfReg.AnnualSum = reg * inputs["omega"]
 	dfReg = hcat(dfReg, DataFrame(reg, :auto))
-	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("Sum");[Symbol("t$t") for t in 1:T]]
+	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfReg,auxNew_Names)
 
-	total = DataFrame(["Total" 0 sum(dfReg[!,:Sum]) fill(0.0, (1,T))], :auto)
+	total = DataFrame(["Total" 0 sum(dfReg.AnnualSum) fill(0.0, (1,T))], :auto)
 	total[!, 4:T+3] .= sum(reg, dims = 1)
 	rename!(total,auxNew_Names)
 	dfReg = vcat(dfReg, total)

--- a/src/write_outputs/reserves/write_rsv.jl
+++ b/src/write_outputs/reserves/write_rsv.jl
@@ -21,18 +21,18 @@ function write_rsv(path::AbstractString, sep::AbstractString, inputs::Dict, setu
 	T = inputs["T"]     # Number of time steps (hours)
 	RSV = inputs["RSV"]
 
-	dfRsv = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone], Sum = Array{Float64}(undef, G))
+	dfRsv = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone])
 	rsv = zeros(G,T)
 	unmet_vec = zeros(T)
 	rsv[RSV, :] = value.(EP[:vRSV][RSV, :])
 	unmet_vec[RSV] = value.(EP[:vUNMET_RSV][RSV])
 	total_unmet = sum(unmet_vec)
-	dfRsv.Sum .= sum(rsv, dims=2)[:]
+	dfRsv.AnnualSum = rsv * inputs["omega"]
 	dfRsv = hcat(dfRsv, DataFrame(rsv, :auto))
-	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("Sum");[Symbol("t$t") for t in 1:T]]
+	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfRsv,auxNew_Names)
 
-	total = DataFrame(["Total" 0 sum(dfRsv[!,:Sum]) zeros(1, T)], :auto)
+	total = DataFrame(["Total" 0 sum(dfRsv.AnnualSum) zeros(1, T)], :auto)
 	unmet = DataFrame(["unmet" 0 total_unmet zeros(1, T)], :auto)
 	total[!, 4:T+3] .= sum(rsv, dims = 1)
 	unmet[!, 4:T+3] .= transpose(unmet_vec)

--- a/src/write_outputs/transmission/write_transmission_flows.jl
+++ b/src/write_outputs/transmission/write_transmission_flows.jl
@@ -19,16 +19,16 @@ function write_transmission_flows(path::AbstractString, sep::AbstractString, set
 	T = inputs["T"]     # Number of time steps (hours)
 	L = inputs["L"]     # Number of transmission lines
 	# Power flows on transmission lines at each time step
-	dfFlow = DataFrame(Line = 1:L, Sum = Array{Float64}(undef, L))
+	dfFlow = DataFrame(Line = 1:L)
 	flow = value.(EP[:vFLOW])
 	if setup["ParameterScale"] == 1
 	    flow *= ModelScalingFactor
 	end
-	dfFlow.Sum .= flow * inputs["omega"]
+	dfFlow.AnnualSum = flow * inputs["omega"]
 	dfFlow = hcat(dfFlow, DataFrame(flow, :auto))
-	auxNew_Names=[Symbol("Line");Symbol("Sum");[Symbol("t$t") for t in 1:T]]
+	auxNew_Names=[Symbol("Line");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfFlow,auxNew_Names)
-	total = DataFrame(["Total" sum(dfFlow[!,:Sum]) fill(0.0, (1,T))], :auto)
+	total = DataFrame(["Total" sum(dfFlow.AnnualSum) fill(0.0, (1,T))], :auto)
 	total[:, 3:T+2] .= sum(flow, dims = 1)
 	rename!(total,auxNew_Names)
 	dfFlow = vcat(dfFlow, total)

--- a/src/write_outputs/transmission/write_transmission_losses.jl
+++ b/src/write_outputs/transmission/write_transmission_losses.jl
@@ -19,18 +19,18 @@ function write_transmission_losses(path::AbstractString, sep::AbstractString, in
 	L = inputs["L"]     # Number of transmission lines
 	LOSS_LINES = inputs["LOSS_LINES"]
 	# Power losses for transmission between zones at each time step
-	dfTLosses = DataFrame(Line = 1:L, Sum = Array{Float64}(undef, L))
+	dfTLosses = DataFrame(Line = 1:L)
 	tlosses = zeros(L, T)
 	tlosses[LOSS_LINES, :] = value.(EP[:vTLOSS][LOSS_LINES, :])
 	if setup["ParameterScale"] == 1
 	    tlosses[LOSS_LINES, :] *= ModelScalingFactor^2
 	end
-	dfTLosses.Sum .= tlosses * inputs["omega"]
+	dfTLosses.AnnualSum = tlosses * inputs["omega"]
 	dfTLosses = hcat(dfTLosses, DataFrame(tlosses, :auto))
-	auxNew_Names=[Symbol("Line");Symbol("Sum");[Symbol("t$t") for t in 1:T]]
+	auxNew_Names=[Symbol("Line");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfTLosses,auxNew_Names)
 
-	total = DataFrame(["Total" sum(dfTLosses[!,:Sum]) fill(0.0, (1,T))], :auto)
+	total = DataFrame(["Total" sum(dfTLosses.AnnualSum) fill(0.0, (1,T))], :auto)
 	total[:, 3:T+2] .= sum(tlosses, dims = 1)
 	rename!(total,auxNew_Names)
 	dfTLosses = vcat(dfTLosses, total)

--- a/src/write_outputs/ucommit/write_shutdown.jl
+++ b/src/write_outputs/ucommit/write_shutdown.jl
@@ -21,14 +21,14 @@ function write_shutdown(path::AbstractString, sep::AbstractString, inputs::Dict,
 	# Operational decision variable states
 	COMMIT = inputs["COMMIT"]
 	# Shutdown state for each resource in each time step
-	dfShutdown = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone], Sum = Array{Union{Missing,Float64}}(undef, G))
+	dfShutdown = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone])
 	shut = zeros(G,T)
 	shut[COMMIT, :] = value.(EP[:vSHUT][COMMIT, :])
-	dfShutdown.Sum .= sum(shut, dims=2)[:]
+	dfShutdown.AnnualSum = shut * inputs["omega"]
 	dfShutdown = hcat(dfShutdown, DataFrame(shut, :auto))
-	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("Sum");[Symbol("t$t") for t in 1:T]]
+	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfShutdown,auxNew_Names)
-	total=DataFrame(["Total" 0 sum(dfShutdown[!,:Sum]) fill(0.0, (1,T))], :auto)
+	total=DataFrame(["Total" 0 sum(dfShutdown.AnnualSum) fill(0.0, (1,T))], :auto)
 	total[:, 4:T+3] .= sum(shut, dims = 1)
 	rename!(total,auxNew_Names)
 	dfShutdown = vcat(dfShutdown, total)

--- a/src/write_outputs/ucommit/write_start.jl
+++ b/src/write_outputs/ucommit/write_start.jl
@@ -20,15 +20,15 @@ function write_start(path::AbstractString, sep::AbstractString, inputs::Dict, se
 	T = inputs["T"]     # Number of time steps (hours)
 	COMMIT = inputs["COMMIT"]
 	# Startup state for each resource in each time step
-	dfStart = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone], Sum = Array{Float64}(undef, G))
+	dfStart = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone])
 	start = zeros(G,T)
 	start[COMMIT, :] = value.(EP[:vSTART][COMMIT, :])
-	dfStart.Sum .= sum(start, dims=2)[:]
+	dfStart.AnnualSum = start * inputs["omega"]
 	dfStart = hcat(dfStart, DataFrame(start, :auto))
-	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("Sum");[Symbol("t$t") for t in 1:T]]
+	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfStart,auxNew_Names)
 
-	total = DataFrame(["Total" 0 sum(dfStart[!,:Sum]) fill(0.0, (1,T))], :auto)
+	total = DataFrame(["Total" 0 sum(dfStart.AnnualSum) fill(0.0, (1,T))], :auto)
 	total[:, 4:T+3] .= sum(start, dims = 1)
 	rename!(total,auxNew_Names)
 	dfStart = vcat(dfStart, total)


### PR DESCRIPTION
The period weighting ω is now taken into account for sums of reg and rsv
values, starts and shutdowns.

Co-authored-by: Qingyu Xu <xuqingyu0610@gmail.com>