### PR TITLE
Include STOR=2 techs in STOR_LONG_DURATION and STOR_SHORT_DURATION sets

### DIFF
--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -47,8 +47,8 @@ function load_generators_data(setup::Dict, path::AbstractString, sep::AbstractSt
 
 	# Set of storage resources with long duration storage capabilitites
 	inputs_gen["STOR_HYDRO_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.HYDRO.==1),:R_ID]
-	inputs_gen["STOR_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.STOR.==1),:R_ID]
-	inputs_gen["STOR_SHORT_DURATION"] = gen_in[(gen_in.LDS.==0) .& (gen_in.STOR.==1),:R_ID]
+	inputs_gen["STOR_LONG_DURATION"] = gen_in[(gen_in.LDS.==1) .& (gen_in.STOR.>=1),:R_ID]
+	inputs_gen["STOR_SHORT_DURATION"] = gen_in[(gen_in.LDS.==0) .& (gen_in.STOR.>=1),:R_ID]
 
 	# Set of all reservoir hydro resources
 	inputs_gen["HYDRO_RES"] = gen_in[(gen_in[!,:HYDRO].==1),:R_ID]


### PR DESCRIPTION
Asymmetric storage is currently excluded from LDS/non-LDS sets. This leads to error (if any LDS is included) where STOR=2 technologies do not get state of charge constraints. 