### PR TITLE
Correcting multi-stage TDR indexing error

### DIFF
--- a/Example_Systems/SmallNewEngland/OneZone_MultiStage/Inputs/Generators_data_multi_period_deprecated.csv
+++ b/Example_Systems/SmallNewEngland/OneZone_MultiStage/Inputs/Generators_data_multi_period_deprecated.csv
@@ -1,5 +1,0 @@
-Resource,Capital_Recovery_Period,Lifetime,Min_Retired_Cap_MW_p1,Min_Retired_Cap_MW_p2,Min_Retired_Cap_MW_p3,Min_Retired_Energy_Cap_MW_p1,Min_Retired_Energy_Cap_MW_p2,Min_Retired_Energy_Cap_MW_p3,Min_Retired_Charge_Cap_MW_p1,Min_Retired_Charge_Cap_MW_p2,Min_Retired_Charge_Cap_MW_p3
-natural_gas_combined_cycle,30,30,1000,2000,3000,0,0,0,0,0,0
-solar_pv,20,20,0,250,250,0,0,0,0,0,0
-onshore_wind,20,20,500,500,0,0,0,0,0,0,0
-battery,15,15,0,0,0,0,0,0,0,0,0

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Run_multi_stage.jl
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Run_multi_stage.jl
@@ -47,7 +47,7 @@ TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFo
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
         println("Clustering Time Series Data...")
-        FinalOutputData, W, RMSE, myTDRsetup, col_to_zone_map, inputs_dict, R, A, M, DistMatrix, ClusteringInputDF = cluster_inputs(inpath, settings_path, mysetup)
+        cluster_inputs(inpath, settings_path, mysetup)
     else
         println("Time Series Data Already Clustered.")
     end

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -134,7 +134,7 @@ function parse_multi_stage_data(inputs_dict)
 
     # LOAD - Load_data.csv
     stage_load_profiles = [ inputs_dict[t]["pD"][:,l] for t in 1:length(keys(inputs_dict)), l in 1:size(inputs_dict[1]["pD"],2) ]
-    vector_lps = [stage_load_profiles[:,t] for t in 1:length(keys(inputs_dict))]
+    vector_lps = [stage_load_profiles[:,l] for l in 1:size(inputs_dict[1]["pD"],2)]
     load_profiles = [reduce(vcat,vector_lps[l]) for l in 1:size(inputs_dict[1]["pD"],2)]
     load_col_names = ["Load_MW_z"*string(l) for l in 1:size(load_profiles)[1]]
     load_zones = [l for l in 1:size(load_profiles)[1]]


### PR DESCRIPTION
The parse_multi_stage_data() function in TDR previously iterated over the wrong dimension, resulting in errors for most examples that do not meet certain specifications (e.g., SmallNewEngland/OneZone_MultiStage) but functioning correctly in others (e.g., ThreeZones_MultiStage). Testing shows that this small fix works for both OneZone and ThreeZones. 