### PR TITLE
DDP Post-convergence extra forward pass

### DIFF
--- a/Example_Systems/SmallNewEngland/OneZone_MultiStage/Run_multi_stage.jl
+++ b/Example_Systems/SmallNewEngland/OneZone_MultiStage/Run_multi_stage.jl
@@ -109,4 +109,4 @@ for p in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
 end
 
 # Step 5) Write DDP summary outputs
-write_multi_stage_outputs(mystats_d, outpath, mysetup)
+write_multi_stage_outputs(mystats_d, outpath, mysetup, inputs_dict)


### PR DESCRIPTION
We identified an error in the current version of DDP where starting capacities in one stage were not guaranteed to be equal to the end capacities in the previous stage. This was due to the backward pass overwriting forward pass model results. While we develop a more sustainable formulation that does not require this extra runtime, this change adds a final forward pass after successful convergence guaranteeing both feasibility and convergence criteria. Tests have shown that the inter-stage capacity mismatches have been corrected by this change. 