### PR TITLE
Fix zonal cost summations

### DIFF
--- a/src/write_outputs/write_costs.jl
+++ b/src/write_outputs/write_costs.jl
@@ -76,12 +76,15 @@ function write_costs(path::AbstractString, sep::AbstractString, inputs::Dict, se
 		if !isempty(STOR_ALL_ZONE)
 			eCVar_in = sum(value.(EP[:eCVar_in][STOR_ALL_ZONE,:]))
 			tempCVar += eCVar_in
-			tempCFix += sum(value.(EP[:eCFixEnergy][STOR_ALL_ZONE]))
+			eCFixEnergy = sum(value.(EP[:eCFixEnergy][STOR_ALL_ZONE]))
+			tempCFix += eCFixEnergy
 
-			tempCTotal += eCVar_in
+			tempCTotal += eCVar_in + eCFixEnergy
 		end
 		if !isempty(STOR_ASYMMETRIC_ZONE)
-			tempCFix += sum(value.(EP[:eCFixCharge][STOR_ASYMMETRIC_ZONE]))
+			eCFixCharge = sum(value.(EP[:eCFixCharge][STOR_ASYMMETRIC_ZONE]))
+			tempCFix += eCFixCharge
+			tempCTotal += eCFixCharge
 		end
 		if !isempty(FLEX_ZONE)
 			eCVarFlex_in = sum(value.(EP[:eCVarFlex_in][FLEX_ZONE,:]))
@@ -96,6 +99,7 @@ function write_costs(path::AbstractString, sep::AbstractString, inputs::Dict, se
 		end
 
 		tempCNSE = sum(value.(EP[:eCNSE][:,:,z]))
+		tempCTotal += tempCNSE
 
 		if setup["ParameterScale"] == 1
 			tempCTotal *= ModelScalingFactor^2


### PR DESCRIPTION
This ensures that the zonal cost subtotals include non-served energy and
the charging- and energycap- related fixed costs of storage resources.

This addresses #63 .