### PR TITLE
Use joinpath rather than manual path construction from strings

### DIFF
--- a/src/additional_tools/method_of_morris_parallel_v0.jl
+++ b/src/additional_tools/method_of_morris_parallel_v0.jl
@@ -54,12 +54,6 @@ function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outp
     #save the variance of effect of each uncertain variable on the objective function
     Morris_range[!,:variance] = DataFrame(m.variances')[!,:x1]
 
-    if setup["MacOrWindows"]=="Mac"
-		sep = "/"
-	else
-		sep = "\U005c"
-	end
-
-    CSV.write(string(outpath,sep,"morris.csv"), Morris_range)
+    CSV.write(joinpath(outpath, "morris.csv"), Morris_range)
 
 end

--- a/src/additional_tools/method_of_morris_v0.jl
+++ b/src/additional_tools/method_of_morris_v0.jl
@@ -22,12 +22,7 @@ We are in the process of implementing Method of Morris for global sensitivity an
 """
 function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outpath::AbstractString, OPTIMIZER)
 
-    if setup["MacOrWindows"]=="Mac"
-		sep = "/"
-	else
-		sep = "\U005c"
-	end
-    Morris_range = DataFrame(CSV.File(string(path, sep,"Method_of_morris_range.csv"), header=true), copycols=true)
+    Morris_range = DataFrame(CSV.File(joinpath(path, "Method_of_morris_range.csv"), header=true), copycols=true)
     save_parameters = zeros(length(Morris_range[!,:Parameter]))
     f1 = function(sigma)
         print(sigma)
@@ -61,6 +56,6 @@ function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outp
     #save the variance of effect of each uncertain variable on the objective function
     Morris_range[!,:variance] = DataFrame(m.variances', :auto)[!,:x1]
 
-    CSV.write(string(outpath,sep,"morris.csv"), Morris_range)
+    CSV.write(joinpath(outpath, "morris.csv"), Morris_range)
 
 end

--- a/src/additional_tools/method_of_morris_v1.jl
+++ b/src/additional_tools/method_of_morris_v1.jl
@@ -157,14 +157,8 @@ function my_gsa(f, p_steps, num_trajectory, total_num_trajectory, p_range::Abstr
 end
 function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outpath::AbstractString, OPTIMIZER)
 
-    if setup["MacOrWindows"]=="Mac"
-		sep = "/"
-	else
-		sep = "\U005c"
-	end
-
     # Reading the input parameters
-    Morris_range = DataFrame(CSV.File(string(path, sep,"Method_of_morris_range.csv"), header=true), copycols=true)
+    Morris_range = DataFrame(CSV.File(joinpath(path, "Method_of_morris_range.csv"), header=true), copycols=true)
     groups = Morris_range[!,:Group]
     p_steps = Morris_range[!,:p_steps]
     total_num_trajectory=Morris_range[!,:total_num_trajectory][1]
@@ -205,6 +199,6 @@ function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outp
     #save the variance of effect of each uncertain variable on the objective function
     Morris_range[!,:variance] = DataFrame(m.variances', :auto)[!,:x1]
 
-    CSV.write(string(outpath,sep,"morris.csv"), Morris_range)
+    CSV.write(joinpath(outpath, "morris.csv"), Morris_range)
 
 end

--- a/src/additional_tools/method_of_morris_v2.jl
+++ b/src/additional_tools/method_of_morris_v2.jl
@@ -176,14 +176,8 @@ function my_gsa(f, p_steps, num_trajectory, total_num_trajectory, p_range::Abstr
 end
 function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outpath::AbstractString, OPTIMIZER)
 
-    if setup["MacOrWindows"]=="Mac"
-		sep = "/"
-	else
-		sep = "\U005c"
-	end
-
     # Reading the input parameters
-    Morris_range = DataFrame(CSV.File(string(path, sep,"Method_of_morris_range.csv"), header=true), copycols=true)
+    Morris_range = DataFrame(CSV.File(joinpath(path, "Method_of_morris_range.csv"), header=true), copycols=true)
     groups = Morris_range[!,:Group]
     p_steps = Morris_range[!,:p_steps]
     total_num_trajectory=Morris_range[!,:total_num_trajectory][1]
@@ -225,6 +219,6 @@ function morris(EP::Model, path::AbstractString, setup::Dict, inputs::Dict, outp
     #save the variance of effect of each uncertain variable on the objective function
     Morris_range[!,:variance] = DataFrame(m.variances', :auto)[!,:x1]
 
-    CSV.write(string(outpath,sep,"morris.csv"), Morris_range)
+    CSV.write(joinpath(outpath, "morris.csv"), Morris_range)
 
 end

--- a/src/load_inputs/load_inputs.jl
+++ b/src/load_inputs/load_inputs.jl
@@ -27,21 +27,12 @@ returns: Dict (dictionary) object containing all data inputs
 """
 function load_inputs(setup::Dict,path::AbstractString)
 
-	## Use appropriate directory separator depending on Mac or Windows config
-	if Sys.isunix()
-		sep = "/"
-    	elseif Sys.iswindows()
-		sep = "\U005c"
-    	else
-        	sep = "/"
-	end
-
 	## Read input files
 	println("Reading Input CSV Files")
 	## Declare Dict (dictionary) object used to store parameters
 	inputs = Dict()
 	# Read input data about power network topology, operating and expansion attributes
-    	if isfile(joinpath(path,"Network.csv"))
+	if isfile(joinpath(path,"Network.csv"))
 		inputs, network_var = load_network_data(setup, path, inputs)
 	else
 		inputs["Z"] = 1
@@ -83,10 +74,11 @@ function load_inputs(setup::Dict,path::AbstractString)
 
 	# Read in mapping of modeled periods to representative periods
 	if is_period_map_necessary(setup, path, inputs) && is_period_map_exist(setup, path, inputs)
-		inputs = load_period_map(setup, path, sep, inputs)
+		inputs = load_period_map(setup, path, inputs)
 	end
-	
-	println("CSV Files Successfully Read In From $path$sep")
+
+	println("CSV Files Successfully Read In From $path")
+
 	return inputs
 end
 

--- a/src/multi_stage/write_settings.jl
+++ b/src/multi_stage/write_settings.jl
@@ -15,12 +15,12 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-    write_settings(outpath::AbstractString, sep::AbstractString, settings_d::Dict)
+    write_settings(outpath::AbstractString, settings_d::Dict)
 
 Function for writing the multi-stage settings file to the output path for future reference.
 """
-function write_settings(outpath::AbstractString, sep::AbstractString, settings_d::Dict)
+function write_settings(outpath::AbstractString, settings_d::Dict)
     multi_stage_settings_d = settings_d["MultiStageSettingsDict"]
-    YAML.write_file(string(outpath,sep,"genx_settings.yml"), settings_d)
-    YAML.write_file(string(outpath,sep,"multi_stage_settings.yml"), multi_stage_settings_d)
+    YAML.write_file(joinpath(outpath, "genx_settings.yml"), settings_d)
+    YAML.write_file(joinpath(outpath, "multi_stage_settings.yml"), multi_stage_settings_d)
 end

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -576,7 +576,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
     if MultiStage == 1
         model_dict=Dict()
         inputs_dict=Dict()
-        inputs_multi_stage = load_inputs_multi_stage(mysetup, string("$inpath/Inputs"))
+        inputs_multi_stage = load_inputs_multi_stage(mysetup, joinpath(inpath, "Inputs"))
         for t in 1:NumStages
 
         	# Step 0) Set Model Year
@@ -945,15 +945,6 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
 
     ##### Step 6: Print to File
 
-#<<<<<<< HEAD
-    if Sys.isunix()
-		sep = "/"
-    elseif Sys.iswindows()
-		sep = "\U005c"
-    else
-        sep = "/"
-	end
-
     if MultiStage == 1
         if v print("Outputs: MultiStage") end
         if MultiStageConcatenate == 1
@@ -982,7 +973,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
 
                 # Save output data to stage-specific locations
                 ### TDR_Results/Load_data_clustered.csv
-                load_in = DataFrame(CSV.File(string(inpath,sep,"Inputs",sep,"Inputs_p$per",sep,"Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+                load_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", "Inputs_p$per", "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
                 load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
                 load_in[1:length(Stage_Weights[per]),:Sub_Weights] .= Stage_Weights[per]
                 load_in[!,:Rep_Periods][1] = length(Stage_Weights[per])
@@ -1001,7 +992,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
                 load_in = load_in[1:size(LPOutputData,1),:]
 
                 if v println("Writing load file...") end
-                CSV.write(string(inpath,sep,"Inputs",sep,Stage_Outfiles[per]["Load"]), load_in)
+                CSV.write(joinpath(inpath, "Inputs", Stage_Outfiles[per]["Load"]), load_in)
 
                 ### TDR_Results/Generators_variability.csv
                 # Reset column ordering, add time index, and solve duplicate column name trouble with CSV.write's header kwarg
@@ -1011,25 +1002,25 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
                 insertcols!(GVOutputData, 1, :Time_Index => 1:size(GVOutputData,1))
                 NewGVColNames = [GVColMap[string(c)] for c in names(GVOutputData)]
                 if v println("Writing resource file...") end
-                CSV.write(string(inpath,sep,"Inputs",sep,Stage_Outfiles[per]["GVar"]), GVOutputData, header=NewGVColNames)
+                CSV.write(joinpath(inpath, "Inputs", Stage_Outfiles[per]["GVar"]), GVOutputData, header=NewGVColNames)
 
                 ### TDR_Results/Fuels_data.csv
-                fuel_in = DataFrame(CSV.File(string(inpath,sep,"Inputs",sep,"Inputs_p$per",sep,"Fuels_data.csv"), header=true), copycols=true)
+                fuel_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", "Inputs_p$per", "Fuels_data.csv"), header=true), copycols=true)
                 select!(fuel_in, Not(:Time_Index))
                 SepFirstRow = DataFrame(fuel_in[1, :])
                 NewFuelOutput = vcat(SepFirstRow, FPOutputData)
                 rename!(NewFuelOutput, FuelCols)
                 insertcols!(NewFuelOutput, 1, :Time_Index => 0:size(NewFuelOutput,1)-1)
                 if v println("Writing fuel profiles...") end
-                CSV.write(string(inpath,sep,"Inputs",sep,Stage_Outfiles[per]["Fuel"]), NewFuelOutput)
+                CSV.write(joinpath(inpath, "Inputs", Stage_Outfiles[per]["Fuel"]), NewFuelOutput)
 
                 ### TDR_Results/Period_map.csv
                 if v println("Writing period map...") end
-                CSV.write(string(inpath,sep,"Inputs",sep,Stage_Outfiles[per]["PMap"]), Stage_PeriodMaps[per])
+                CSV.write(joinpath(inpath, "Inputs", Stage_Outfiles[per]["PMap"]), Stage_PeriodMaps[per])
 
                 ### TDR_Results/time_domain_reduction_settings.yml
                 if v println("Writing .yml settings...") end
-                YAML.write_file(string(inpath,sep,"Inputs",sep,Stage_Outfiles[per]["YAML"]), myTDRsetup)
+                YAML.write_file(joinpath(inpath, "Inputs", Stage_Outfiles[per]["YAML"]), myTDRsetup)
 
             end
 
@@ -1038,7 +1029,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             mkpath(joinpath(inpath,"Inputs","Inputs_p1", TimeDomainReductionFolder))
 
             ### TDR_Results/Load_data.csv
-            load_in = DataFrame(CSV.File(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,"Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+            load_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", "Inputs_p1", "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
             load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
             load_in[1:length(W),:Sub_Weights] .= W
             load_in[!,:Rep_Periods][1] = length(W)
@@ -1057,7 +1048,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             load_in = load_in[1:size(LPOutputData,1),:]
 
             if v println("Writing load file...") end
-            CSV.write(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,Load_Outfile), load_in)
+            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", Load_Outfile), load_in)
 
             ### TDR_Results/Generators_variability.csv
 
@@ -1068,33 +1059,33 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             insertcols!(GVOutputData, 1, :Time_Index => 1:size(GVOutputData,1))
             NewGVColNames = [GVColMap[string(c)] for c in names(GVOutputData)]
             if v println("Writing resource file...") end
-            CSV.write(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,GVar_Outfile), GVOutputData, header=NewGVColNames)
+            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", GVar_Outfile), GVOutputData, header=NewGVColNames)
 
             ### TDR_Results/Fuels_data.csv
 
-            fuel_in = DataFrame(CSV.File(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,"Fuels_data.csv"), header=true), copycols=true)
+            fuel_in = DataFrame(CSV.File(string(inpath, "Inputs", "Inputs_p1", "Fuels_data.csv"), header=true), copycols=true)
             select!(fuel_in, Not(:Time_Index))
             SepFirstRow = DataFrame(fuel_in[1, :])
             NewFuelOutput = vcat(SepFirstRow, FPOutputData)
             rename!(NewFuelOutput, FuelCols)
             insertcols!(NewFuelOutput, 1, :Time_Index => 0:size(NewFuelOutput,1)-1)
             if v println("Writing fuel profiles...") end
-            CSV.write(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,Fuel_Outfile), NewFuelOutput)
+            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", Fuel_Outfile), NewFuelOutput)
 
             ### Period_map.csv
             if v println("Writing period map...") end
-            CSV.write(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,PMap_Outfile), PeriodMap)
+            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", PMap_Outfile), PeriodMap)
 
             ### time_domain_reduction_settings.yml
             if v println("Writing .yml settings...") end
-            YAML.write_file(string(inpath,sep,"Inputs",sep,"Inputs_p1",sep,YAML_Outfile), myTDRsetup)
+            YAML.write_file(joinpath(inpath, "Inputs", "Inputs_p1", YAML_Outfile), myTDRsetup)
         end
     else
         if v println("Outputs: Single-Stage") end
         mkpath(joinpath(inpath, TimeDomainReductionFolder))
 
         ### TDR_Results/Load_data.csv
-        load_in = DataFrame(CSV.File(string(inpath,sep,"Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+        load_in = DataFrame(CSV.File(joinpath(inpath, "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
         load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
         load_in[1:length(W),:Sub_Weights] .= W
         load_in[!,:Rep_Periods][1] = length(W)
@@ -1113,7 +1104,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
         load_in = load_in[1:size(LPOutputData,1),:]
 
         if v println("Writing load file...") end
-        CSV.write(string(inpath,sep,Load_Outfile), load_in)
+        CSV.write(joinpath(inpath, Load_Outfile), load_in)
 
         ### TDR_Results/Generators_variability.csv
 
@@ -1124,26 +1115,26 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
         insertcols!(GVOutputData, 1, :Time_Index => 1:size(GVOutputData,1))
         NewGVColNames = [GVColMap[string(c)] for c in names(GVOutputData)]
         if v println("Writing resource file...") end
-        CSV.write(string(inpath,sep,GVar_Outfile), GVOutputData, header=NewGVColNames)
+        CSV.write(joinpath(inpath, GVar_Outfile), GVOutputData, header=NewGVColNames)
 
         ### TDR_Results/Fuels_data.csv
 
-        fuel_in = DataFrame(CSV.File(string(inpath,sep,"Fuels_data.csv"), header=true), copycols=true)
+        fuel_in = DataFrame(CSV.File(joinpath(inpath, "Fuels_data.csv"), header=true), copycols=true)
         select!(fuel_in, Not(:Time_Index))
         SepFirstRow = DataFrame(fuel_in[1, :])
         NewFuelOutput = vcat(SepFirstRow, FPOutputData)
         rename!(NewFuelOutput, FuelCols)
         insertcols!(NewFuelOutput, 1, :Time_Index => 0:size(NewFuelOutput,1)-1)
         if v println("Writing fuel profiles...") end
-        CSV.write(string(inpath,sep,Fuel_Outfile), NewFuelOutput)
+        CSV.write(joinpath(inpath, Fuel_Outfile), NewFuelOutput)
 
         ### TDR_Results/Period_map.csv
         if v println("Writing period map...") end
-        CSV.write(string(inpath,sep,PMap_Outfile), PeriodMap)
+        CSV.write(joinpath(inpath, PMap_Outfile), PeriodMap)
 
         ### TDR_Results/time_domain_reduction_settings.yml
         if v println("Writing .yml settings...") end
-        YAML.write_file(string(inpath,sep,YAML_Outfile), myTDRsetup)
+        YAML.write_file(joinpath(inpath, YAML_Outfile), myTDRsetup)
     end
 
     return Dict("OutputDF" => FinalOutputData,

--- a/src/write_outputs/capacity_reserve_margin/write_capacity_value.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_capacity_value.jl
@@ -14,7 +14,7 @@ in LICENSE.txt.  Users uncompressing this from an archive may not have
 received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-function write_capacity_value(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_capacity_value(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -67,5 +67,5 @@ function write_capacity_value(path::AbstractString, sep::AbstractString, inputs:
 		rename!(temp_dfCapValue, auxNew_Names)
 		append!(dfCapValue, temp_dfCapValue)
 	end
-	CSV.write(string(path,sep,"CapacityValue.csv"), dfCapValue)
+	CSV.write(joinpath(path, "CapacityValue.csv"), dfCapValue)
 end

--- a/src/write_outputs/capacity_reserve_margin/write_reserve_margin_revenue.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_reserve_margin_revenue.jl
@@ -15,7 +15,7 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	write_reserve_margin_revenue(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	write_reserve_margin_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 
 Function for reporting the capacity revenue earned by each generator listed in the input file.
     GenX will print this file only when capacity reserve margin is modeled and the shadow price can be obtained form the solver.
@@ -24,7 +24,7 @@ Function for reporting the capacity revenue earned by each generator listed in t
     The last column is the total revenue received from all capacity reserve margin constraints.
     As a reminder, GenX models the capacity reserve margin (aka capacity market) at the time-dependent level, and each constraint either stands for an overall market or a locality constraint.
 """
-function write_reserve_margin_revenue(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_reserve_margin_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -56,6 +56,6 @@ function write_reserve_margin_revenue(path::AbstractString, sep::AbstractString,
 		dfResRevenue = hcat(dfResRevenue, DataFrame([tempresrev], [sym]))
 	end
 	dfResRevenue.AnnualSum = annual_sum
-	CSV.write(string(path,sep,"ReserveMarginRevenue.csv"), dfResRevenue)
+	CSV.write(joinpath(path, "ReserveMarginRevenue.csv"), dfResRevenue)
 	return dfResRevenue
 end

--- a/src/write_outputs/reserves/write_rsv.jl
+++ b/src/write_outputs/reserves/write_rsv.jl
@@ -39,5 +39,5 @@ function write_rsv(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	rename!(total,auxNew_Names)
 	rename!(unmet,auxNew_Names)
 	dfRsv = vcat(dfRsv, unmet, total)
-	CSV.write(string(path,sep,"reg_dn.csv"), dftranspose(dfRsv, false), writeheader=false)
+	CSV.write(joinpath(path, "reg_dn.csv"), dftranspose(dfRsv, false), writeheader=false)
 end

--- a/src/write_outputs/transmission/write_transmission_flows.jl
+++ b/src/write_outputs/transmission/write_transmission_flows.jl
@@ -32,5 +32,5 @@ function write_transmission_flows(path::AbstractString, inputs::Dict, setup::Dic
 	total[:, 3:T+2] .= sum(flow, dims = 1)
 	rename!(total,auxNew_Names)
 	dfFlow = vcat(dfFlow, total)
-	CSV.write(string(path,sep,"flow.csv"), dftranspose(dfFlow, false), writeheader=false)
+	CSV.write(joinpath(path, "flow.csv"), dftranspose(dfFlow, false), writeheader=false)
 end

--- a/src/write_outputs/transmission/write_transmission_losses.jl
+++ b/src/write_outputs/transmission/write_transmission_losses.jl
@@ -34,5 +34,5 @@ function write_transmission_losses(path::AbstractString, inputs::Dict, setup::Di
 	total[:, 3:T+2] .= sum(tlosses, dims = 1)
 	rename!(total,auxNew_Names)
 	dfTLosses = vcat(dfTLosses, total)
-	CSV.write(string(path,sep,"tlosses.csv"), dftranspose(dfTLosses, false), writeheader=false)
+	CSV.write(joinpath(path, "tlosses.csv"), dftranspose(dfTLosses, false), writeheader=false)
 end

--- a/src/write_outputs/write_charging_cost.jl
+++ b/src/write_outputs/write_charging_cost.jl
@@ -14,7 +14,7 @@ in LICENSE.txt.  Users uncompressing this from an archive may not have
 received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-function write_charging_cost(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_charging_cost(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -32,6 +32,6 @@ function write_charging_cost(path::AbstractString, sep::AbstractString, inputs::
 	    chargecost *= ModelScalingFactor^2
 	end
 	dfChargingcost.AnnualSum .= chargecost * inputs["omega"]
-	CSV.write(string(path,sep,"ChargingCost.csv"), dfChargingcost)
+	CSV.write(joinpath(path, "ChargingCost.csv"), dfChargingcost)
 	return dfChargingcost
 end

--- a/src/write_outputs/write_energy_revenue.jl
+++ b/src/write_outputs/write_energy_revenue.jl
@@ -15,11 +15,11 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	write_energy_revenue(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	write_energy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 
 Function for writing energy revenue from the different generation technologies.
 """
-function write_energy_revenue(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_energy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -35,6 +35,6 @@ function write_energy_revenue(path::AbstractString, sep::AbstractString, inputs:
 		energyrevenue *= ModelScalingFactor^2
 	end
 	dfEnergyRevenue.AnnualSum .= energyrevenue * inputs["omega"]
-	CSV.write(string(path,sep,"EnergyRevenue.csv"), dfEnergyRevenue)
+	CSV.write(joinpath(path, "EnergyRevenue.csv"), dfEnergyRevenue)
 	return dfEnergyRevenue
 end

--- a/src/write_outputs/write_nse.jl
+++ b/src/write_outputs/write_nse.jl
@@ -44,6 +44,6 @@ function write_nse(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	rename!(total,auxNew_Names)
 	dfNse = vcat(dfNse, total)
 
-	CSV.write(string(path,sep,"nse.csv"),  dftranspose(dfNse, false), writeheader=false)
+	CSV.write(joinpath(path, "nse.csv"),  dftranspose(dfNse, false), writeheader=false)
 	return dfNse
 end

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -139,8 +139,8 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 		dfRegSubRevenue = DataFrame()
 		if has_duals(EP) == 1
 			dfPrice = write_price(path, inputs, setup, EP)
-			dfEnergyRevenue = write_energy_revenue(path, sep, inputs, setup, EP)
-			dfChargingcost = write_charging_cost(path, sep, inputs, setup, EP)
+			dfEnergyRevenue = write_energy_revenue(path, inputs, setup, EP)
+			dfChargingcost = write_charging_cost(path, inputs, setup, EP)
 			dfSubRevenue, dfRegSubRevenue = write_subsidy_revenue(path, inputs, setup, EP)
 		end
 
@@ -160,8 +160,8 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 			elapsed_time_rsv_margin = @elapsed write_reserve_margin_w(path, inputs, setup, EP)
 		  println("Time elapsed for writing reserve margin is")
 		  println(elapsed_time_rsv_margin)
-			dfResRevenue = write_reserve_margin_revenue(path, sep, inputs, setup, EP)
-			elapsed_time_cap_value = @elapsed write_capacity_value(path, sep, inputs, setup, EP)
+			dfResRevenue = write_reserve_margin_revenue(path, inputs, setup, EP)
+			elapsed_time_cap_value = @elapsed write_capacity_value(path, inputs, setup, EP)
 		  println("Time elapsed for writing capacity value is")
 		  println(elapsed_time_cap_value)
 		end

--- a/src/write_outputs/write_power.jl
+++ b/src/write_outputs/write_power.jl
@@ -41,6 +41,6 @@ function write_power(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 
 	rename!(total,auxNew_Names)
 	dfPower = vcat(dfPower, total)
-	CSV.write(string(path,sep,"power.csv"), dftranspose(dfPower, false), writeheader=false)
+	CSV.write(joinpath(path, "power.csv"), dftranspose(dfPower, false), writeheader=false)
 	return dfPower
 end

--- a/src/write_outputs/write_power_balance.jl
+++ b/src/write_outputs/write_power_balance.jl
@@ -67,5 +67,5 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
 	dfPowerBalance = hcat(dfPowerBalance, DataFrame(powerbalance, :auto))
 	auxNew_Names = [Symbol("BalanceComponent"); Symbol("Zone"); Symbol("AnnualSum"); [Symbol("t$t") for t in 1:T]]
 	rename!(dfPowerBalance,auxNew_Names)
-	CSV.write(string(path,sep,"power_balance.csv"), dftranspose(dfPowerBalance, false), writeheader=false)
+	CSV.write(joinpath(path, "power_balance.csv"), dftranspose(dfPowerBalance, false), writeheader=false)
 end


### PR DESCRIPTION
This simplifies functions by removing the unneeded 'sep' argument and by using the julia builtin `joinpath` to construct paths with appropriate directory separators.