### PR TITLE
Remove 'sep' from write output functions

### DIFF
--- a/src/write_outputs/capacity_reserve_margin/write_capacity_value.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_capacity_value.jl
@@ -14,7 +14,7 @@ in LICENSE.txt.  Users uncompressing this from an archive may not have
 received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-function write_capacity_value(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_capacity_value(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -67,5 +67,5 @@ function write_capacity_value(path::AbstractString, sep::AbstractString, inputs:
 		rename!(temp_dfCapValue, auxNew_Names)
 		append!(dfCapValue, temp_dfCapValue)
 	end
-	CSV.write(string(path,sep,"CapacityValue.csv"), dfCapValue)
+	CSV.write(joinpath(path,"CapacityValue.csv"), dfCapValue)
 end

--- a/src/write_outputs/capacity_reserve_margin/write_reserve_margin_revenue.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_reserve_margin_revenue.jl
@@ -24,7 +24,7 @@ Function for reporting the capacity revenue earned by each generator listed in t
     The last column is the total revenue received from all capacity reserve margin constraints.
     As a reminder, GenX models the capacity reserve margin (aka capacity market) at the time-dependent level, and each constraint either stands for an overall market or a locality constraint.
 """
-function write_reserve_margin_revenue(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_reserve_margin_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -56,6 +56,6 @@ function write_reserve_margin_revenue(path::AbstractString, sep::AbstractString,
 		dfResRevenue = hcat(dfResRevenue, DataFrame([tempresrev], [sym]))
 	end
 	dfResRevenue.AnnualSum = annual_sum
-	CSV.write(string(path,sep,"ReserveMarginRevenue.csv"), dfResRevenue)
+	CSV.write(joinpath(path,"ReserveMarginRevenue.csv"), dfResRevenue)
 	return dfResRevenue
 end

--- a/src/write_outputs/reserves/write_rsv.jl
+++ b/src/write_outputs/reserves/write_rsv.jl
@@ -39,5 +39,5 @@ function write_rsv(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	rename!(total,auxNew_Names)
 	rename!(unmet,auxNew_Names)
 	dfRsv = vcat(dfRsv, unmet, total)
-	CSV.write(string(path,sep,"reg_dn.csv"), dftranspose(dfRsv, false), writeheader=false)
+	CSV.write(string(path,"reg_dn.csv"), dftranspose(dfRsv, false), writeheader=false)
 end

--- a/src/write_outputs/transmission/write_transmission_flows.jl
+++ b/src/write_outputs/transmission/write_transmission_flows.jl
@@ -32,5 +32,5 @@ function write_transmission_flows(path::AbstractString, inputs::Dict, setup::Dic
 	total[:, 3:T+2] .= sum(flow, dims = 1)
 	rename!(total,auxNew_Names)
 	dfFlow = vcat(dfFlow, total)
-	CSV.write(string(path,sep,"flow.csv"), dftranspose(dfFlow, false), writeheader=false)
+	CSV.write(joinpath(path,"flow.csv"), dftranspose(dfFlow, false), writeheader=false)
 end

--- a/src/write_outputs/transmission/write_transmission_losses.jl
+++ b/src/write_outputs/transmission/write_transmission_losses.jl
@@ -34,5 +34,5 @@ function write_transmission_losses(path::AbstractString, inputs::Dict, setup::Di
 	total[:, 3:T+2] .= sum(tlosses, dims = 1)
 	rename!(total,auxNew_Names)
 	dfTLosses = vcat(dfTLosses, total)
-	CSV.write(string(path,sep,"tlosses.csv"), dftranspose(dfTLosses, false), writeheader=false)
+	CSV.write(joinpath(path,"tlosses.csv"), dftranspose(dfTLosses, false), writeheader=false)
 end

--- a/src/write_outputs/write_charging_cost.jl
+++ b/src/write_outputs/write_charging_cost.jl
@@ -14,7 +14,7 @@ in LICENSE.txt.  Users uncompressing this from an archive may not have
 received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-function write_charging_cost(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_charging_cost(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -32,6 +32,6 @@ function write_charging_cost(path::AbstractString, sep::AbstractString, inputs::
 	    chargecost *= ModelScalingFactor^2
 	end
 	dfChargingcost.AnnualSum .= chargecost * inputs["omega"]
-	CSV.write(string(path,sep,"ChargingCost.csv"), dfChargingcost)
+	CSV.write(joinpath(path,"ChargingCost.csv"), dfChargingcost)
 	return dfChargingcost
 end

--- a/src/write_outputs/write_energy_revenue.jl
+++ b/src/write_outputs/write_energy_revenue.jl
@@ -19,7 +19,7 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 
 Function for writing energy revenue from the different generation technologies.
 """
-function write_energy_revenue(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_energy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
 	T = inputs["T"]     # Number of time steps (hours)
@@ -35,6 +35,6 @@ function write_energy_revenue(path::AbstractString, sep::AbstractString, inputs:
 		energyrevenue *= ModelScalingFactor^2
 	end
 	dfEnergyRevenue.AnnualSum .= energyrevenue * inputs["omega"]
-	CSV.write(string(path,sep,"EnergyRevenue.csv"), dfEnergyRevenue)
+	CSV.write(joinpath(path,"EnergyRevenue.csv"), dfEnergyRevenue)
 	return dfEnergyRevenue
 end

--- a/src/write_outputs/write_nse.jl
+++ b/src/write_outputs/write_nse.jl
@@ -44,6 +44,6 @@ function write_nse(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	rename!(total,auxNew_Names)
 	dfNse = vcat(dfNse, total)
 
-	CSV.write(string(path,sep,"nse.csv"),  dftranspose(dfNse, false), writeheader=false)
+	CSV.write(joinpath(path,"nse.csv"),  dftranspose(dfNse, false), writeheader=false)
 	return dfNse
 end

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -139,8 +139,8 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 		dfRegSubRevenue = DataFrame()
 		if has_duals(EP) == 1
 			dfPrice = write_price(path, inputs, setup, EP)
-			dfEnergyRevenue = write_energy_revenue(path, sep, inputs, setup, EP)
-			dfChargingcost = write_charging_cost(path, sep, inputs, setup, EP)
+			dfEnergyRevenue = write_energy_revenue(path, inputs, setup, EP)
+			dfChargingcost = write_charging_cost(path, inputs, setup, EP)
 			dfSubRevenue, dfRegSubRevenue = write_subsidy_revenue(path, inputs, setup, EP)
 		end
 
@@ -160,8 +160,8 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 			elapsed_time_rsv_margin = @elapsed write_reserve_margin_w(path, inputs, setup, EP)
 		  println("Time elapsed for writing reserve margin is")
 		  println(elapsed_time_rsv_margin)
-			dfResRevenue = write_reserve_margin_revenue(path, sep, inputs, setup, EP)
-			elapsed_time_cap_value = @elapsed write_capacity_value(path, sep, inputs, setup, EP)
+			dfResRevenue = write_reserve_margin_revenue(path, inputs, setup, EP)
+			elapsed_time_cap_value = @elapsed write_capacity_value(path, inputs, setup, EP)
 		  println("Time elapsed for writing capacity value is")
 		  println(elapsed_time_cap_value)
 		end

--- a/src/write_outputs/write_power.jl
+++ b/src/write_outputs/write_power.jl
@@ -41,6 +41,6 @@ function write_power(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 
 	rename!(total,auxNew_Names)
 	dfPower = vcat(dfPower, total)
-	CSV.write(string(path,sep,"power.csv"), dftranspose(dfPower, false), writeheader=false)
+	CSV.write(joinpath(path,"power.csv"), dftranspose(dfPower, false), writeheader=false)
 	return dfPower
 end

--- a/src/write_outputs/write_power_balance.jl
+++ b/src/write_outputs/write_power_balance.jl
@@ -67,5 +67,5 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
 	dfPowerBalance = hcat(dfPowerBalance, DataFrame(powerbalance, :auto))
 	auxNew_Names = [Symbol("BalanceComponent"); Symbol("Zone"); Symbol("AnnualSum"); [Symbol("t$t") for t in 1:T]]
 	rename!(dfPowerBalance,auxNew_Names)
-	CSV.write(string(path,sep,"power_balance.csv"), dftranspose(dfPowerBalance, false), writeheader=false)
+	CSV.write(joinpath(path,"power_balance.csv"), dftranspose(dfPowerBalance, false), writeheader=false)
 end


### PR DESCRIPTION
There are several issues submitted with 'sep' not being defined in 11 write output files. This resolves them.