### PR TITLE
Prevent writing_storagedual if there's no STOR > 0

### DIFF
--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -94,9 +94,11 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 		elapsed_time_reliability = @elapsed write_reliability(path, inputs, setup, EP)
 		println("Time elapsed for writing reliability is")
 		println(elapsed_time_reliability)
-		elapsed_time_stordual = @elapsed write_storagedual(path, inputs, setup, EP)
-		println("Time elapsed for writing storage duals is")
-		println(elapsed_time_stordual)
+		if !isempty(inputs["STOR_ALL"])
+			elapsed_time_stordual = @elapsed write_storagedual(path, inputs, setup, EP)
+			println("Time elapsed for writing storage duals is")
+			println(elapsed_time_stordual)
+		end
 	end
 
 	if setup["UCommit"] >= 1

--- a/src/write_outputs/write_storagedual.jl
+++ b/src/write_outputs/write_storagedual.jl
@@ -38,7 +38,6 @@ function write_storagedual(path::AbstractString, inputs::Dict, setup::Dict, EP::
 	# Loop over W separately hours_per_subperiod
 	STOR_ALL_NONLDS = setdiff(STOR_ALL, inputs["STOR_LONG_DURATION"])
 	STOR_ALL_LDS = intersect(STOR_ALL, inputs["STOR_LONG_DURATION"])
-	println("STOR ALL LDS is ", STOR_ALL_LDS)
 	dual_values[STOR_ALL, INTERIOR_SUBPERIODS] = (dual.(EP[:cSoCBalInterior][INTERIOR_SUBPERIODS, STOR_ALL]).data ./ inputs["omega"][INTERIOR_SUBPERIODS])'
 	dual_values[STOR_ALL_NONLDS, START_SUBPERIODS] = (dual.(EP[:cSoCBalStart][START_SUBPERIODS, STOR_ALL_NONLDS]).data ./ inputs["omega"][START_SUBPERIODS])'
 	if !isempty(STOR_ALL_LDS)


### PR DESCRIPTION
This fixes issue #224, (and #172 which I'm fairly sure is the same).

We also remove a line that prints STOR_ALL_LDS, as an aesthetic fix.

As a bugfix, it would be great if this could be quickly merged to `main`.

