### PR TITLE
Multi-stage TDR update with parameter scaling fix

### DIFF
--- a/Example_Systems/MethodofMorrisExample/OneZone/Run.jl
+++ b/Example_Systems/MethodofMorrisExample/OneZone/Run.jl
@@ -37,11 +37,20 @@ mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings
 #mysetup = YAML.load(open(genx_settings)) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/MethodofMorrisExample/OneZone/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/MethodofMorrisExample/OneZone/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 11
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 6
 
@@ -80,7 +80,14 @@ WeightTotal: 8760
   #   number of timesteps in the raw input data.
 ClusterFuelPrices: 1
 
-  #   - UseExtremePeriods 
+  #   - MultiStageConcatenate
+  #   (Only considered if MultiStage = 1 in genx_settings.yml)
+  #   If 1, this designates that the model should time domain reduce the input data
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
+
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
@@ -89,11 +96,11 @@ UseExtremePeriods: 1
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -117,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 1
       System:
@@ -131,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 1
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/RealSystemExample/ISONE_Singlezone/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Singlezone/Run.jl
@@ -39,11 +39,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/RealSystemExample/ISONE_Trizone/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone/Run.jl
@@ -36,11 +36,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Run.jl
@@ -36,11 +36,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 11
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 8
 
@@ -80,7 +80,14 @@ WeightTotal: 8760
   #   number of timesteps in the raw input data.
 ClusterFuelPrices: 1
 
-  #   - UseExtremePeriods 
+  #   - MultiStageConcatenate
+  #   (Only considered if MultiStage = 1 in genx_settings.yml)
+  #   If 1, this designates that the model should time domain reduce the input data
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
+
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
@@ -89,11 +96,11 @@ UseExtremePeriods: 1
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -117,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 1
       System:
@@ -131,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 1
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Run.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Run.jl
@@ -36,11 +36,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Run_multi_stage.jl
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Run_multi_stage.jl
@@ -43,11 +43,20 @@ multistage_settings = joinpath(settings_path, "multi_stage_settings.yml") # Mult
 mysetup["MultiStageSettingsDict"] = YAML.load(open(multistage_settings))
 
 ### Cluster time series inputs if necessary and if specified by the user
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
 TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        FinalOutputData, W, RMSE, myTDRsetup, col_to_zone_map, inputs_dict, R, A, M, DistMatrix, ClusteringInputDF = cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 10
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 10
 
@@ -83,12 +83,11 @@ ClusterFuelPrices: 1
   #   - MultiStageConcatenate
   #   (Only considered if MultiStage = 1 in genx_settings.yml)
   #   If 1, this designates that the model should time domain reduce the input data
-  #   of all model stages together. Else if 0, [still in development] the model will time domain reduce only
-  #   the first stage and will apply the periods of each other model stage to this set
-  #   of representative periods by closest Eucliden distance.
-MultiStageConcatenate: 1
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
 
-  #   - UseExtremePeriods 
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
@@ -97,11 +96,11 @@ UseExtremePeriods: 1
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -125,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 0
       System:
@@ -139,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 0
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Run.jl
+++ b/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Run.jl
@@ -36,11 +36,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 11
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 8
 
@@ -80,7 +80,14 @@ WeightTotal: 8760
   #   number of timesteps in the raw input data.
 ClusterFuelPrices: 1
 
-  #   - UseExtremePeriods 
+  #   - MultiStageConcatenate
+  #   (Only considered if MultiStage = 1 in genx_settings.yml)
+  #   If 1, this designates that the model should time domain reduce the input data
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
+
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
@@ -89,11 +96,11 @@ UseExtremePeriods: 1
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -117,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 1
       System:
@@ -131,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 1
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/SmallNewEngland/OneZone/Run.jl
+++ b/Example_Systems/SmallNewEngland/OneZone/Run.jl
@@ -37,11 +37,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/SmallNewEngland/OneZone/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 11
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 8
 
@@ -80,28 +80,27 @@ WeightTotal: 8760
   #   number of timesteps in the raw input data.
 ClusterFuelPrices: 1
 
-  #   - UseExtremePeriods 
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
   #   minimum wind cf as extreme periods.
 UseExtremePeriods: 1
 
-  #   - MultiStageConcatenate 
+  #   - MultiStageConcatenate
   #   (Only considered if MultiStage = 1 in genx_settings.yml)
   #   If 1, this designates that the model should time domain reduce the input data
-  #   of all model stages together. Else if 0, [still in development] the model will time domain reduce only
-  #   the first stage and will apply the periods of each other model stage to this set
-  #   of representative periods by closest Eucliden distance.
-MultiStageConcatenate: 1
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -125,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 1
       System:
@@ -139,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 1
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/SmallNewEngland/OneZone_3VREBin/Run.jl
+++ b/Example_Systems/SmallNewEngland/OneZone_3VREBin/Run.jl
@@ -36,11 +36,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/SmallNewEngland/OneZone_3VREBin/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone_3VREBin/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 11
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 6
 
@@ -80,7 +80,14 @@ WeightTotal: 8760
   #   number of timesteps in the raw input data.
 ClusterFuelPrices: 1
 
-  #   - UseExtremePeriods 
+  #   - MultiStageConcatenate
+  #   (Only considered if MultiStage = 1 in genx_settings.yml)
+  #   If 1, this designates that the model should time domain reduce the input data
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
+
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
@@ -89,11 +96,11 @@ UseExtremePeriods: 1
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -117,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 1
       System:
@@ -131,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 1
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/SmallNewEngland/OneZone_MultiStage/Run_multi_stage.jl
+++ b/Example_Systems/SmallNewEngland/OneZone_MultiStage/Run_multi_stage.jl
@@ -43,11 +43,20 @@ multistage_settings = joinpath(settings_path, "multi_stage_settings.yml") # Mult
 mysetup["MultiStageSettingsDict"] = YAML.load(open(multistage_settings))
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        FinalOutputData, W, RMSE, myTDRsetup, col_to_zone_map, inputs_dict = cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/SmallNewEngland/OneZone_MultiStage/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone_MultiStage/Settings/time_domain_reduction_settings.yml
@@ -83,10 +83,9 @@ ClusterFuelPrices: 1
   #   - MultiStageConcatenate
   #   (Only considered if MultiStage = 1 in genx_settings.yml)
   #   If 1, this designates that the model should time domain reduce the input data
-  #   of all model stages together. Else if 0, [still in development] the model will time domain reduce only
-  #   the first stage and will apply the periods of each other model stage to this set
-  #   of representative periods by closest Eucliden distance.
-MultiStageConcatenate: 1
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
 
   #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include

--- a/Example_Systems/SmallNewEngland/ThreeZones/Run.jl
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Run.jl
@@ -36,11 +36,20 @@ genx_settings = joinpath(settings_path, "genx_settings.yml") #Settings YAML file
 mysetup = configure_settings(genx_settings) # mysetup dictionary stores settings and GenX-specific parameters
 
 ### Cluster time series inputs if necessary and if specified by the user
-TDRpath = joinpath(inpath, mysetup["TimeDomainReductionFolder"])
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
+TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/SmallNewEngland/ThreeZones/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Settings/time_domain_reduction_settings.yml
@@ -5,29 +5,29 @@
 #  Set parameters here that organize how your full timeseries
 #   data will be divided into representative period clusters.
 #   Ensure that time_domain_reduction is set to 1 in GenX_settings.yml
-#   before running. Run within GenX or use PreCluster.jl to test and 
-#   examine representative period output before proceeding. 
+#   before running. Run within GenX or use PreCluster.jl to test and
+#   examine representative period output before proceeding.
 #   Specify your data input directory as inpath within Run_test.jl
-#   or PreCluster.jl. 
-#   
+#   or PreCluster.jl.
+#
 #####
 
-  #   - TimestepsPerRepPeriod 
-  #   Typically 168 timesteps (e.g., hours) per period, this designates 
+  #   - TimestepsPerRepPeriod
+  #   Typically 168 timesteps (e.g., hours) per period, this designates
   #   the length of each representative period.
 TimestepsPerRepPeriod: 168
 
-  #   - ClusterMethod 
+  #   - ClusterMethod
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
   #   periods and determine each point's representative period.
 ClusterMethod: 'kmeans'
 
-  #   - ScalingMethod 
+  #   - ScalingMethod
   #   Either 'N' or 'S', this designates directs the module to normalize ([0,1])
   #   or standardize (mean 0, variance 1) the input data.
 ScalingMethod: "S"
 
-  #   - MaxPeriods 
+  #   - MaxPeriods
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
@@ -35,7 +35,7 @@ MaxPeriods: 11
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
-  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
+  #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
 MinPeriods: 8
 
@@ -80,28 +80,27 @@ WeightTotal: 8760
   #   number of timesteps in the raw input data.
 ClusterFuelPrices: 1
 
-  #   - UseExtremePeriods 
+  #   - UseExtremePeriods
   #   Either 'yes' or 'no', this designates whether or not to include
   #   outliers (by performance or load/resource extreme) as their own representative periods.
   #   This setting automatically includes the periods with maximum load, minimum solar cf and
   #   minimum wind cf as extreme periods.
 UseExtremePeriods: 1
 
-  #   - MultiStageConcatenate 
+  #   - MultiStageConcatenate
   #   (Only considered if MultiStage = 1 in genx_settings.yml)
   #   If 1, this designates that the model should time domain reduce the input data
-  #   of all model stages together. Else if 0, [still in development] the model will time domain reduce only
-  #   the first stage and will apply the periods of each other model stage to this set
-  #   of representative periods by closest Eucliden distance.
-MultiStageConcatenate: 1
+  #   of all model stages together. Else if 0, the model will time domain reduce each
+  #   stage separately
+MultiStageConcatenate: 0
 
 # STILL IN DEVELOPMENT - Currently just uses integral max load, integral min PV and wind.
 #   - ExtremePeriods
-#   Use this to define which periods to be included among the final representative periods 
-#   as "Extreme Periods". 
+#   Use this to define which periods to be included among the final representative periods
+#   as "Extreme Periods".
 #   Select by profile type: load ("Load"), solar PV capacity factors ("PV"), and wind capacity factors ("Wind").
-#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System"). 
-#   Select whether to look for absolute max/min at the timestep level ("Absolute") 
+#   Select whether to examine these profiles by zone ("Zone") or across the whole system ("System").
+#   Select whether to look for absolute max/min at the timestep level ("Absolute")
 #      or max/min sum across the period ("Integral").
 #   Select whether you want the maximum ("Max") or minimum ("Min") (of the prior type) for each profile type.
 ExtremePeriods:
@@ -125,7 +124,7 @@ ExtremePeriods:
          Absolute:
             Max: 0
             Min: 0
-         Integral:   
+         Integral:
             Max: 0
             Min: 1
       System:
@@ -139,14 +138,14 @@ ExtremePeriods:
       Zone:
          Absolute:
             Max: 0
-            Min: 0  
+            Min: 0
          Integral:
             Max: 0
             Min: 1
       System:
          Absolute:
             Max: 0
-            Min: 0 
+            Min: 0
          Integral:
             Max: 0
             Min: 0

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Run_multi_stage.jl
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Run_multi_stage.jl
@@ -43,11 +43,20 @@ multistage_settings = joinpath(settings_path, "multi_stage_settings.yml") # Mult
 mysetup["MultiStageSettingsDict"] = YAML.load(open(multistage_settings))
 
 ### Cluster time series inputs if necessary and if specified by the user
+tdr_settings = joinpath(settings_path, "time_domain_reduction_settings.yml") # Multi stage settings YAML file path
+TDRSettingsDict = YAML.load(open(tdr_settings))
 TDRpath = joinpath(inpath, "Inputs", "Inputs_p1", mysetup["TimeDomainReductionFolder"])
 if mysetup["TimeDomainReduction"] == 1
     if (!isfile(TDRpath*"/Load_data.csv")) || (!isfile(TDRpath*"/Generators_variability.csv")) || (!isfile(TDRpath*"/Fuels_data.csv"))
-        println("Clustering Time Series Data...")
-        cluster_inputs(inpath, settings_path, mysetup)
+        if (mysetup["MultiStage"] == 1) && (TDRSettingsDict["MultiStageConcatenate"] == 0)
+			println("Clustering Time Series Data (Individually)...")
+			for stage_id in 1:mysetup["MultiStageSettingsDict"]["NumStages"]
+				cluster_inputs(inpath, settings_path, mysetup, stage_id)
+			end
+		else
+			println("Clustering Time Series Data (Grouped)...")
+        	cluster_inputs(inpath, settings_path, mysetup)
+		end
     else
         println("Time Series Data Already Clustered.")
     end

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/time_domain_reduction_settings.yml
@@ -37,13 +37,13 @@ MaxPeriods: 11
   #   The minimum number of periods used to represent the input data. If using
   #   UseExtremePeriods, this must be at least the number of extreme periods requests. If
   #   IterativelyAddPeriods if off, this will be the total number of periods.
-MinPeriods: 8
+MinPeriods: 11
 
   #   - IterativelyAddPeriods
-  #   Either 'yes' or 'no', this designates whether or not to add periods
+  #   Either 1 (yes) or 0 (no), this designates whether or not to add periods
   #   until the error threshold between input data and represented data is met or the maximum
   #   number of periods is reached.
-IterativelyAddPeriods: 1
+IterativelyAddPeriods: 0
 
   #   - IterateMethod
   #   Either 'cluster' or 'extreme', this designates whether to add clusters to
@@ -83,10 +83,9 @@ ClusterFuelPrices: 1
   #   - MultiStageConcatenate
   #   (Only considered if MultiStage = 1 in genx_settings.yml)
   #   If 1, this designates that the model should time domain reduce the input data
-  #   of all model stages together. Else if 0, [still in development] the model will time domain reduce only
-  #   the first stage and will apply the periods of each other model stage to this set
-  #   of representative periods by closest Eucliden distance.
-MultiStageConcatenate: 1
+  #   of all model stages together. Else if 0, the model will time domain reduce each 
+  #   stage separately
+MultiStageConcatenate: 0
 
   #   - UseExtremePeriods
   #   Either 1 (yes) or 0 (no), this designates whether or not to include
@@ -133,7 +132,7 @@ ExtremePeriods:
             Min: 0
          Integral:
             Max: 0
-            Min: 0
+            Min: 1
    Wind:
       Zone:
          Absolute:
@@ -148,4 +147,4 @@ ExtremePeriods:
             Min: 0
          Integral:
             Max: 0
-            Min: 0
+            Min: 1

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -531,7 +531,7 @@ In Load_data.csv, include the following:
      the first stage and will apply the periods of each other model stage to this set
      of representative periods by closest Eucliden distance.
 """
-function cluster_inputs(inpath, settings_path, mysetup, v=false)
+function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
     if v println(now()) end
 
     ##### Step 0: Load in settings and data
@@ -569,14 +569,19 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
     YAML_Outfile = joinpath(TimeDomainReductionFolder, "time_domain_reduction_settings.yml")
 
     # Define a local version of the setup so that you can modify the mysetup["ParameterScale"] value to be zero in case it is 1
-    mysetup_local = mysetup
+    mysetup_local = copy(mysetup)
     # If ParameterScale =1 then make it zero, since clustered inputs will be scaled prior to generating model
     mysetup_local["ParameterScale"]=0  # Performing cluster and report outputs in user-provided units
+
+    # Define another local version of setup such that Multi-Stage Non-Concatentation TDR can iteratively read in the raw data
+    mysetup_MS = copy(mysetup)
+    mysetup_MS["TimeDomainReduction"]=0
+    mysetup_MS["DoNotReadPeriodMap"]=1
+    mysetup_MS["ParameterScale"]=0
 
     if MultiStage == 1
         model_dict=Dict()
         inputs_dict=Dict()
-        inputs_multi_stage = load_inputs_multi_stage(mysetup, joinpath(inpath, "Inputs"))
         for t in 1:NumStages
 
         	# Step 0) Set Model Year
@@ -585,13 +590,12 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
         	# Step 1) Load Inputs
         	global inpath_sub = string("$inpath/Inputs/Inputs_p",t)
 
-        	inputs_dict[t] = load_inputs(mysetup, inpath_sub)
+        	inputs_dict[t] = load_inputs(mysetup_MS, inpath_sub)
 
-        	merge!(inputs_dict[t],inputs_multi_stage)
         	inputs_dict[t] = configure_multi_stage_inputs(inputs_dict[t],mysetup["MultiStageSettingsDict"],mysetup["NetworkExpansion"])
         end
         if MultiStageConcatenate == 1
-            println("MultiStage with Concatenation")
+            if v println("MultiStage with Concatenation") end
             RESOURCE_ZONES = inputs_dict[1]["RESOURCE_ZONES"]
             RESOURCES = inputs_dict[1]["RESOURCES"]
             ZONES = inputs_dict[1]["R_ZONES"]
@@ -601,8 +605,9 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
                  load_profiles, var_profiles, solar_profiles, wind_profiles, fuel_profiles, all_profiles,
                  col_to_zone_map, AllFuelsConst, stage_lengths, total_length, relative_lengths = parse_multi_stage_data(inputs_dict)
         else # TDR each period individually
-            println("MultiStage without Concatenation")
-            myinputs = inputs_dict[1]
+            if v println("MultiStage without Concatenation") end
+            if v println("---> STAGE ", stage_id) end
+            myinputs = inputs_dict[stage_id]
             RESOURCE_ZONES = myinputs["RESOURCE_ZONES"]
             RESOURCES = myinputs["RESOURCES"]
             ZONES = myinputs["R_ZONES"]
@@ -611,10 +616,9 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             load_col_names, var_col_names, solar_col_names, wind_col_names, fuel_col_names, all_col_names,
                  load_profiles, var_profiles, solar_profiles, wind_profiles, fuel_profiles, all_profiles,
                  col_to_zone_map, AllFuelsConst = parse_data(myinputs)
-            println("TDR for each individual stage has not yet been FULLY implemented.")
         end
     else
-        println("Not MultiStage")
+        if v println("Not MultiStage") end
         myinputs = load_inputs(mysetup_local,inpath)
         RESOURCE_ZONES = myinputs["RESOURCE_ZONES"]
         RESOURCES = myinputs["RESOURCES"]
@@ -1025,11 +1029,13 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             end
 
         else
-            println("without Concatenation has not yet been fully implemented.")
-            mkpath(joinpath(inpath,"Inputs","Inputs_p1", TimeDomainReductionFolder))
+            if v print("without Concatenation has not yet been fully implemented. ") end
+            if v println("( STAGE ", stage_id, " )") end
+            input_stage_directory = "Inputs_p"*string(stage_id)
+            mkpath(joinpath(inpath,"Inputs",input_stage_directory, TimeDomainReductionFolder))
 
             ### TDR_Results/Load_data.csv
-            load_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", "Inputs_p1", "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+            load_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", input_stage_directory, "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
             load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
             load_in[1:length(W),:Sub_Weights] .= W
             load_in[!,:Rep_Periods][1] = length(W)
@@ -1048,7 +1054,7 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             load_in = load_in[1:size(LPOutputData,1),:]
 
             if v println("Writing load file...") end
-            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", Load_Outfile), load_in)
+            CSV.write(joinpath(inpath,"Inputs",input_stage_directory,Load_Outfile), load_in)
 
             ### TDR_Results/Generators_variability.csv
 
@@ -1059,26 +1065,26 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
             insertcols!(GVOutputData, 1, :Time_Index => 1:size(GVOutputData,1))
             NewGVColNames = [GVColMap[string(c)] for c in names(GVOutputData)]
             if v println("Writing resource file...") end
-            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", GVar_Outfile), GVOutputData, header=NewGVColNames)
+            CSV.write(joinpath(inpath,"Inputs",input_stage_directory,GVar_Outfile), GVOutputData, header=NewGVColNames)
 
             ### TDR_Results/Fuels_data.csv
 
-            fuel_in = DataFrame(CSV.File(string(inpath, "Inputs", "Inputs_p1", "Fuels_data.csv"), header=true), copycols=true)
+            fuel_in = DataFrame(CSV.File(joinpath(inpath,"Inputs",input_stage_directory,"Fuels_data.csv"), header=true), copycols=true)
             select!(fuel_in, Not(:Time_Index))
             SepFirstRow = DataFrame(fuel_in[1, :])
             NewFuelOutput = vcat(SepFirstRow, FPOutputData)
             rename!(NewFuelOutput, FuelCols)
             insertcols!(NewFuelOutput, 1, :Time_Index => 0:size(NewFuelOutput,1)-1)
             if v println("Writing fuel profiles...") end
-            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", Fuel_Outfile), NewFuelOutput)
+            CSV.write(joinpath(inpath,"Inputs",input_stage_directory,Fuel_Outfile), NewFuelOutput)
 
             ### Period_map.csv
             if v println("Writing period map...") end
-            CSV.write(joinpath(inpath, "Inputs", "Inputs_p1", PMap_Outfile), PeriodMap)
+            CSV.write(joinpath(inpath,"Inputs",input_stage_directory,PMap_Outfile), PeriodMap)
 
             ### time_domain_reduction_settings.yml
             if v println("Writing .yml settings...") end
-            YAML.write_file(joinpath(inpath, "Inputs", "Inputs_p1", YAML_Outfile), myTDRsetup)
+            YAML.write_file(joinpath(inpath,"Inputs",input_stage_directory,YAML_Outfile), myTDRsetup)
         end
     else
         if v println("Outputs: Single-Stage") end
@@ -1146,61 +1152,4 @@ function cluster_inputs(inpath, settings_path, mysetup, v=false)
                 "Weights" => W,
                 "Centers" => M,
                 "RMSE" => RMSE)
-#=
-    mkpath(joinpath(inpath, TimeDomainReductionFolder))
-
-    ### Load_data_clustered.csv
-    load_in = DataFrame(CSV.File(joinpath(inpath, "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
-    load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
-    load_in[1:length(W),:Sub_Weights] .= W
-    load_in[!,:Rep_Periods][1] = length(W)
-    load_in[!,:Timesteps_per_Rep_Period][1] = TimestepsPerRepPeriod
-    select!(load_in, Not(LoadCols))
-    select!(load_in, Not(:Time_Index))
-    Time_Index_M = Union{Int64, Missings.Missing}[missing for i in 1:size(load_in,1)]
-    Time_Index_M[1:size(LPOutputData,1)] = 1:size(LPOutputData,1)
-    load_in[!,:Time_Index] .= Time_Index_M
-
-    for c in LoadCols
-        new_col = Union{Float64, Missings.Missing}[missing for i in 1:size(load_in,1)]
-        new_col[1:size(LPOutputData,1)] = LPOutputData[!,c]
-        load_in[!,c] .= new_col
-    end
-    load_in = load_in[1:size(LPOutputData,1),:]
-
-    if v println("Writing load file...") end
-    CSV.write(joinpath(inpath, Load_Outfile), load_in)
-
-    ### Generators_variability_clustered.csv
-
-    # Reset column ordering, add time index, and solve duplicate column name trouble with CSV.write's header kwarg
-    GVColMap = Dict(myinputs["RESOURCE_ZONES"][i] => myinputs["RESOURCES"][i] for i in 1:length(myinputs["RESOURCES"]))
-    GVColMap["Time_Index"] = "Time_Index"
-    GVOutputData = GVOutputData[!, Symbol.(myinputs["RESOURCE_ZONES"])]
-    insertcols!(GVOutputData, 1, :Time_Index => 1:size(GVOutputData,1))
-    NewGVColNames = [GVColMap[string(c)] for c in names(GVOutputData)]
-    if v println("Writing resource file...") end
-    CSV.write(joinpath(inpath, GVar_Outfile), GVOutputData, header=NewGVColNames)
-
-    ### Fuels_data_clustered.csv
-
-    fuel_in = DataFrame(CSV.File(joinpath(inpath, "Fuels_data.csv"), header=true), copycols=true)
-    select!(fuel_in, Not(:Time_Index))
-    SepFirstRow = DataFrame(fuel_in[1, :])
-    NewFuelOutput = vcat(SepFirstRow, FPOutputData)
-    rename!(NewFuelOutput, FuelCols)
-    insertcols!(NewFuelOutput, 1, :Time_Index => 0:size(NewFuelOutput,1)-1)
-    if v println("Writing fuel profiles...") end
-    CSV.write(joinpath(inpath, Fuel_Outfile), NewFuelOutput)
-
-    ### Period_map.csv
-    if v println("Writing period map...") end
-    CSV.write(joinpath(inpath, PMap_Outfile), PeriodMap)
-
-    ### time_domain_reduction_settings.yml
-    if v println("Writing .yml settings...") end
-    YAML.write_file(joinpath(inpath, YAML_Outfile), myTDRsetup)
-
-    return FinalOutputData, W, RMSE, myTDRsetup, col_to_zone_map
->>>>>>> main =#
 end


### PR DESCRIPTION
This pull request includes one functional change and one bug fix. Before this request, multi-stage time domain reduction would concatenate the input data of all stages, run one TDR operation for the whole set, and distribute TDR outputs to each stage directory accordingly. This pull request allows the user to instead run TDR for each stage individually using the setting MultiStageConcatenate=0 in time_domain_reduction_settings.yml. Additionally, an aliasing issue led to improper parameter scaling behavior under some settings. This pull request fixes this issue by creating a copy of the settings dictionary. Changes to the run files and settings files are applied to each example in the examples directory. 