### PR TITLE
Disabled CI and builds on Julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ julia:
   #- 1.3
   #- 1.5
   - 1.6
-  - nightly
+  #- nightly
 coveralls: true
 branches:
   only:
@@ -24,7 +24,7 @@ cache:
 jobs:
   fast_finish: true
   allow_failures:
-    - julia: nightly
+   # - julia: nightly
   include:
     - stage: Documentation
       julia: 1.6


### PR DESCRIPTION
Disabled until tests are run locally on Julia 1.7.x,1.8.x, and 1.9.x and debugged in order to prevent failures on codes that should run without any problem on Julia 1.6.x