### PR TITLE
load_generator_data modification

### DIFF
--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -67,6 +67,10 @@ function load_generators_data(setup::Dict, path::AbstractString, inputs_gen::Dic
 	inputs_gen["VRE"] = gen_in[gen_in.VRE.>=1,:R_ID]
 
 	# Set of retrofit resources
+	if !("RETRO" in names(gen_in))
+		gen_in[!, "RETRO"] = zero(gen_in[!, "R_ID"])
+	end
+		
 	inputs_gen["RETRO"] = gen_in[gen_in.RETRO.==1,:R_ID]
 
 	# Set of thermal generator resources


### PR DESCRIPTION
To make sure that files that do not have RETRO column in the Generators_data.csv are read error free by creating a dummy RETRO column for them with all zero entries