### PR TITLE
Fix multistage DDP bug for output writing

### DIFF
--- a/src/GenX.jl
+++ b/src/GenX.jl
@@ -195,10 +195,17 @@ include("write_outputs/write_outputs.jl")
 include("simple_operation.jl")
 
 # Multi Stage files
+include("multi_stage/write_multi_stage_settings.jl")
+include("multi_stage/write_multi_stage_capacities_discharge.jl")
+include("multi_stage/write_multi_stage_capacities_charge.jl")
+include("multi_stage/write_multi_stage_capacities_energy.jl")
+include("multi_stage/write_multi_stage_network_expansion.jl")
+include("multi_stage/write_multi_stage_costs.jl")
+include("multi_stage/write_multi_stage_stats.jl")
+include("multi_stage/write_multi_stage_settings.jl")
 include("multi_stage/dual_dynamic_programming.jl")
 include("multi_stage/configure_multi_stage_inputs.jl")
 include("multi_stage/endogenous_retirement.jl")
-include("multi_stage/write_multi_stage_settings.jl")
 
 include("additional_tools/modeling_to_generate_alternatives.jl")
 include("additional_tools/method_of_morris.jl")

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -279,7 +279,9 @@ function write_multi_stage_outputs(stats_d::Dict, outpath::String, settings_d::D
     write_multi_stage_capacities_discharge(outpath, multi_stage_settings_d)
     write_multi_stage_capacities_charge(outpath, multi_stage_settings_d)
     write_multi_stage_capacities_energy(outpath, multi_stage_settings_d)
-    write_multi_stage_network_expansion(outpath, multi_stage_settings_d)
+    if settings_d["NetworkExpansion"] == 1
+    	write_multi_stage_network_expansion(outpath, multi_stage_settings_d)
+    end
     write_multi_stage_costs(outpath, multi_stage_settings_d, inputs_dict)
     write_multi_stage_stats(outpath, stats_d)
     write_multi_stage_settings(outpath, settings_d)


### PR DESCRIPTION
This PR attempts to fix writing of different multi-stage outputs by mentioning the relevant files in GenX.jl and accounting for network expansion