### PR TITLE
Time Varying Startup Cost

### DIFF
--- a/src/model/core/ucommit.jl
+++ b/src/model/core/ucommit.jl
@@ -32,7 +32,7 @@ $\zeta_{y,t,z}$ represents number of shutdown decisions in cluster $y$ in zone $
 The total cost of start-ups across all generators subject to unit commitment ($y \in UC$) and all time periods, t is expressed as:
 ```math
 \begin{aligned}
-	C^{start} = \sum_{y \in UC, t \in T} \omega_t \times start\_cost_{y} \times \chi_{y,t}
+	C^{start} = \sum_{y \in UC, t \in T} \omega_t \times start\_cost_{y,t} \times \chi_{y,t}
 \end{aligned}
 ```
 
@@ -64,7 +64,7 @@ function ucommit!(EP::Model, inputs::Dict, setup::Dict)
 	## Objective Function Expressions ##
 
 	# Startup costs of "generation" for resource "y" during hour "t"
-	@expression(EP, eCStart[y in COMMIT, t=1:T],(inputs["omega"][t]*inputs["C_Start"][y]*vSTART[y,t]))
+	@expression(EP, eCStart[y in COMMIT, t=1:T],(inputs["omega"][t]*inputs["C_Start"][y,t]*vSTART[y,t]))
 
 	# Julia is fastest when summing over one row one column at a time
 	@expression(EP, eTotalCStartT[t=1:T], sum(eCStart[y,t] for y in COMMIT))


### PR DESCRIPTION
This PR attempts to modify the startup cost formulation in commit.jl to reflect the variation with the hours. Instead of the original formulation:

`@expression(EP, eCStart[y in COMMIT, t=1:T],(inputs["omega"][t]*inputs["C_Start"][y]*vSTART[y,t]))`

it's now written as

`@expression(EP, eCStart[y in COMMIT, t=1:T],(inputs["omega"][t]*inputs["C_Start"][y,t]*vSTART[y,t]))`

And the doctoring has also been adjusted.