### PR TITLE
Added Julia 1.7, 1.8, 1.9, and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ julia:
   #- 1.3
   #- 1.5
   - 1.6
-  #- nightly
+  - 1.7
+  - 1.8
+  - 1.9
+  - nightly
 coveralls: true
 branches:
   only:


### PR DESCRIPTION
Reinstated the nightly Julia build and added versions 1.7, 1.8, and 1.9 of Julia to enable language upgrades to GenX