### PR TITLE
Add zone list interface for loading the network map

### DIFF
--- a/docs/src/data_documentation.md
+++ b/docs/src/data_documentation.md
@@ -179,8 +179,8 @@ This input file contains input parameters related to: 1) definition of model zon
 | :------------ | :-----------|
 |**Settings-specific Columns**|
 |**Multiple zone model**||
-|Network\_Lines | Numerical index for each network line/|
-| z* (Network map) | Next n columns, one per zone, with column header in format of z* where * is the number of the zone. L rows, one for each network line (or interregional path), with a 1 in the column corresponding to the 'origin' zone and a -1 in the column corresponding to the 'destination' zone for each line. No more than one column may be marked as origin and one as destination for each line, or the model will not function correctly. Note that positive flows indicate flow from origin to destination zone; negative flows indicate flow from destination to origin zone.|
+|Network\_Lines | Numerical index for each network line. The length of this column is counted but the actual values are not used.|
+| z* (Network map) **OR** Origin_Zone, Destination_Zone | See below |
 |Line\_Max\_Flow\_MW | Existing capacity of the inter-regional transmission line.|
 |**NetworkExpansion = 1**||
 |Line\_Max\_Reinforcement\_MW |Maximum allowable capacity addition to the existing transmission line.|
@@ -199,6 +199,31 @@ This input file contains input parameters related to: 1) definition of model zon
 |**MultiStage == 1**|
 |Capital\_Recovery\_Period  |Capital recovery period (in years) used for determining overnight capital costs from annualized investment costs for network transmission line expansion.  |
 |Line\_Max\_Flow\_Possible\_MW  |Maximum possible line flow in the current model period. Overrides Line\_Max\_Reinforcement\_MW, which is not used when performing multi-stage modeling.  |
+
+There are two interfaces implemented for specifying the network topology itself: a matrix interface and a list interface.
+Only one choice is permitted in a given file.
+
+The list interface consists of a column for the lines origin zone and one for the line's destination zone.
+Here is a snippet of the Network.csv file for a map with three zones and two lines:
+```
+Network_Lines, Origin_Zone, Destination_Zone,
+            1,           1,                2,
+            2,           1,                3,
+```
+
+The matrix interface requires N columns labeled `z1, z2, z3 ... zN`,
+and L rows, one for each network line (or interregional path), with a `1` in the column corresponding to the 'origin' zone 
+and a `-1` in the column corresponding to the 'destination' zone for each line.
+Here is the same network map implemented as a matrix:
+```
+Network_Lines, z1, z2, z3,
+            1,  1, -1,  0,
+            2,  1,  0, -1,
+```
+
+Note that in either case, positive flows indicate flow from origin to destination zone;
+negative flows indicate flow from destination to origin zone.
+
 
 #### 2.1.3 Load\_data.csv
 

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -106,9 +106,9 @@ end
 
 Loads the network map from a list-style interface
 ```
-..., Network_Lines, Start_Node, End_Node, ...
-                 1,          1,        2,
-                 2,          1,        3,
+..., Network_Lines, Origin_Zone, Destination_Zone, ...
+                 1,           1,                2,
+                 2,           1,                3,
 ```
 """
 function load_network_map_from_list(network_var::DataFrame, Z, L, list_columns)
@@ -144,7 +144,7 @@ end
 function load_network_map(network_var::DataFrame, Z, L)
     columns = names(network_var)
 
-    list_columns = ["Start_Node", "End_Node"]
+    list_columns = ["Origin_Zone", "Destination_Zone"]
     has_network_list = all([c in columns for c in list_columns])
 
     zones_as_strings = ["z" * string(i) for i in 1:Z]

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -101,6 +101,16 @@ function load_network_data(setup::Dict, path::AbstractString, inputs_nw::Dict)
     return inputs_nw, network_var
 end
 
+@doc raw"""
+    load_network_map_from_list(network_var::DataFrame, Z, L, list_columns)
+
+Loads the network map from a list-style interface
+```
+..., Network_Lines, Start_Node, End_Node, ...
+                 1,          1,        2,
+                 2,          1,        3,
+```
+"""
 function load_network_map_from_list(network_var::DataFrame, Z, L, list_columns)
     start_col, end_col = list_columns
     mat = zeros(L, Z)
@@ -113,6 +123,18 @@ function load_network_map_from_list(network_var::DataFrame, Z, L, list_columns)
     mat
 end
 
+@doc raw"""
+    load_network_map_from_matrix(network_var::DataFrame, Z, L)
+
+Loads the network map from a matrix-style interface
+```
+..., Network_Lines, z1, z2, z3, ...
+                 1,  1, -1,  0,
+                 2,  1,  0, -1,
+```
+This is equivalent to the list-style interface where the zone zN with entry +1 is the
+starting node of the line and the zone with entry -1 is the ending node of the line.
+"""
 function load_network_map_from_matrix(network_var::DataFrame, Z, L)
     # Topology of the network source-sink matrix
     col = findall(s -> s == "z1", names(network_var))[1]

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -22,94 +22,70 @@ Function for reading input parameters related to the electricity transmission ne
 #DEV NOTE:  add DC power flow related parameter inputs in a subsequent commit
 function load_network_data(setup::Dict, path::AbstractString, inputs_nw::Dict)
 
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
+
     # Network zones inputs and Network topology inputs
     network_var = DataFrame(CSV.File(joinpath(path,"Network.csv"), header=true), copycols=true)
 
+    function to_array(col::Symbol)
+        return convert(Array{Float64}, collect(skipmissing(network_var[!, col])))
+    end
+
     # Number of zones in the network
-    inputs_nw["Z"] = size(findall(s -> (startswith(s, "z")) & (tryparse(Float64, s[2:end]) != nothing), names(network_var)),1)
-    Z = inputs_nw["Z"]
+    Z = length(to_array(:Network_zones))
+    inputs_nw["Z"] = Z
     # Number of lines in the network
-    inputs_nw["L"]=size(collect(skipmissing(network_var[!,:Network_Lines])),1)
+    L = length(collect(skipmissing(network_var[!,:Network_Lines])))
+    inputs_nw["L"] = L
 
     # Topology of the network source-sink matrix
     start = findall(s -> s == "z1", names(network_var))[1]
-    inputs_nw["pNet_Map"] = Matrix{Float64}(network_var[1:inputs_nw["L"],start:start+inputs_nw["Z"]-1])
+    inputs_nw["pNet_Map"] = Matrix{Float64}(network_var[1:L, start:start+Z-1])
 
     # Transmission capacity of the network (in MW)
-    if setup["ParameterScale"] ==1  # Parameter scaling turned on - adjust values of subset of parameter values to GW
-        inputs_nw["pTrans_Max"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Max_Flow_MW])))/ModelScalingFactor  # convert to GW
-    else # no scaling
-        inputs_nw["pTrans_Max"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Max_Flow_MW])))
-    end
+    inputs_nw["pTrans_Max"] = to_array(:Line_Max_Flow_MW) / scale_factor  # convert to GW
 
-    if setup["Trans_Loss_Segments"] == 1 ##Aaron Schwartz Please check
+    if setup["Trans_Loss_Segments"] == 1
         # Line percentage Loss - valid for case when modeling losses as a fixed percent of absolute value of power flows
-        inputs_nw["pPercent_Loss"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Loss_Percentage])))
+        inputs_nw["pPercent_Loss"] = to_array(:Line_Loss_Percentage)
     elseif setup["Trans_Loss_Segments"] >= 2
         # Transmission line voltage (in kV)
-        inputs_nw["kV"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Voltage_kV])))
+        inputs_nw["kV"] = to_array(:Line_Voltage_kV)
         # Transmission line resistance (in Ohms) - Used when modeling quadratic transmission losses
-        inputs_nw["Ohms"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Resistance_ohms])))
+        inputs_nw["Ohms"] = to_array(:Line_Resistance_ohms)
     end
 
     # Maximum possible flow after reinforcement for use in linear segments of piecewise approximation
-    inputs_nw["pTrans_Max_Possible"] = zeros(Float64, inputs_nw["L"])
+    inputs_nw["pTrans_Max_Possible"] = inputs_nw["pTrans_Max"]
 
     if setup["NetworkExpansion"]==1
-        if setup["ParameterScale"] ==1  # Parameter scaling turned on - adjust values of subset of parameter values
-            # Read between zone network reinforcement costs per peak MW of capacity added
-            inputs_nw["pC_Line_Reinforcement"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Reinforcement_Cost_per_MWyr])))/ModelScalingFactor # convert to million $/GW/yr with objective function in millions
-            # Maximum reinforcement allowed in MW
-            #NOTE: values <0 indicate no expansion possible
-            inputs_nw["pMax_Line_Reinforcement"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Max_Reinforcement_MW])))/ModelScalingFactor # convert to GW
-        else
-            # Read between zone network reinforcement costs per peak MW of capacity added
-            inputs_nw["pC_Line_Reinforcement"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Reinforcement_Cost_per_MWyr])))
-            # Maximum reinforcement allowed in MW
-            #NOTE: values <0 indicate no expansion possible
-            inputs_nw["pMax_Line_Reinforcement"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Max_Reinforcement_MW])))
-        end
-        for l in 1:inputs_nw["L"]
-            if inputs_nw["pMax_Line_Reinforcement"][l] > 0
-                inputs_nw["pTrans_Max_Possible"][l] = inputs_nw["pTrans_Max"][l] + inputs_nw["pMax_Line_Reinforcement"][l]
-            else
-                inputs_nw["pTrans_Max_Possible"][l] = inputs_nw["pTrans_Max"][l]
-            end
-        end
-    else
-        inputs_nw["pTrans_Max_Possible"] = inputs_nw["pTrans_Max"]
+        # Read between zone network reinforcement costs per peak MW of capacity added
+        inputs_nw["pC_Line_Reinforcement"] = to_array(:Line_Reinforcement_Cost_per_MWyr) / scale_factor # convert to million $/GW/yr with objective function in millions
+        # Maximum reinforcement allowed in MW
+        #NOTE: values <0 indicate no expansion possible
+        inputs_nw["pMax_Line_Reinforcement"] = map(x->max(0, x), to_array(:Line_Max_Reinforcement_MW)) / scale_factor # convert to GW
+        inputs_nw["pTrans_Max_Possible"] += inputs_nw["pMax_Line_Reinforcement"]
     end
 
     # Multi-Stage
     if setup["MultiStage"] == 1
         # Weighted Average Cost of Capital for Transmission Expansion
         if setup["NetworkExpansion"]>=1
-            inputs_nw["transmission_WACC"]= convert(Array{Float64}, collect(skipmissing(network_var[!,:WACC])))
-            inputs_nw["Capital_Recovery_Period_Trans"]= convert(Array{Float64}, collect(skipmissing(network_var[!,:Capital_Recovery_Period])))
+            inputs_nw["transmission_WACC"]= to_array(:WACC)
+            inputs_nw["Capital_Recovery_Period_Trans"]= to_array(:Capital_Recovery_Period)
         end
 
         # Max Flow Possible on Each Line
-        if setup["ParameterScale"] == 1
-            inputs_nw["pLine_Max_Flow_Possible_MW"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Max_Flow_Possible_MW])))/ModelScalingFactor # Convert to GW
-        else
-            inputs_nw["pLine_Max_Flow_Possible_MW"] = convert(Array{Float64}, collect(skipmissing(network_var[!,:Line_Max_Flow_Possible_MW])))
-        end
+        inputs_nw["pLine_Max_Flow_Possible_MW"] = to_array(:Line_Max_Flow_Possible_MW) / scale_factor # Convert to GW
     end
 
     # Transmission line (between zone) loss coefficient (resistance/voltage^2)
-    inputs_nw["pTrans_Loss_Coef"] = zeros(Float64, inputs_nw["L"])
-    for l in 1:inputs_nw["L"]
-        # For cases with only one segment
-        if setup["Trans_Loss_Segments"] == 1
-            inputs_nw["pTrans_Loss_Coef"][l] = inputs_nw["pPercent_Loss"][l]
-        elseif setup["Trans_Loss_Segments"] >= 2
-            # If zones are connected, loss coefficient is R/V^2 where R is resistance in Ohms and V is voltage in Volts
-            if setup["ParameterScale"] ==1  # Parameter scaling turned on - adjust values of subset of parameter values
-                inputs_nw["pTrans_Loss_Coef"][l] = (inputs_nw["Ohms"][l]/10^6)/(inputs_nw["kV"][l]/10^3)^2 *ModelScalingFactor # 1/GW ***
-            else
-                inputs_nw["pTrans_Loss_Coef"][l] = (inputs_nw["Ohms"][l]/10^6)/(inputs_nw["kV"][l]/10^3)^2 # 1/MW
-            end
-        end
+    inputs_nw["pTrans_Loss_Coef"] = zeros(Float64, L)
+    if setup["Trans_Loss_Segments"] == 1
+        inputs_nw["pTrans_Loss_Coef"] = inputs_nw["pPercent_Loss"]
+    elseif setup["Trans_Loss_Segments"] >= 2
+        # If zones are connected, loss coefficient is R/V^2 where R is resistance in Ohms and V is voltage in Volts
+        inputs_nw["pTrans_Loss_Coef"] = (inputs_nw["Ohms"]/10^6)/(inputs_nw["kV"]/10^3)^2 * scale_factor # 1/GW ***
     end
 
     ## Sets and indices for transmission losses and expansion


### PR DESCRIPTION
The network map can now be loaded from columns

```
Network_Lines, Origin_Zone, Destination_Zone
1, 1, 2
2, 1, 3
```
in addition to still supporting the direct matrix format,
```
Network_Lines, z1, z2, z3
1, 1, -1, 0
2, 1, 0, -1
```