### PR TITLE
Functionalize Dataframe loading from csv

### DIFF
--- a/src/GenX.jl
+++ b/src/GenX.jl
@@ -20,6 +20,7 @@ module GenX
 export configure_settings
 export configure_solver
 export load_inputs
+export load_dataframe
 export generate_model
 export solve_model
 export write_outputs
@@ -85,6 +86,7 @@ include("configure_solver/configure_cbc.jl")
 include("configure_solver/configure_solver.jl")
 
 # Load input data
+include("load_inputs/load_dataframe.jl")
 include("load_inputs/load_generators_data.jl")
 include("load_inputs/load_generators_variability.jl")
 include("load_inputs/load_network_data.jl")

--- a/src/load_inputs/load_cap_reserve_margin.jl
+++ b/src/load_inputs/load_cap_reserve_margin.jl
@@ -15,45 +15,42 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_cap_reserve_margin(setup::Dict, path::AbstractString, inputs_crm::Dict)
+	load_cap_reserve_margin!(setup::Dict, path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to planning reserve margin constraints
+Read input parameters related to planning reserve margin constraints
 """
-function load_cap_reserve_margin(setup::Dict, path::AbstractString, inputs_crm::Dict)
-	# Definition of capacity reserve margin (crm) by locational deliverability area (LDA)
-	inputs_crm["dfCapRes"] = DataFrame(CSV.File(joinpath(path, "Capacity_reserve_margin.csv"), header=true), copycols=true)
+function load_cap_reserve_margin!(setup::Dict, path::AbstractString, inputs::Dict)
+    filename = "Capacity_reserve_margin.csv"
+    # Definition of capacity reserve margin (crm) by locational deliverability area (LDA)
+    df = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
 
-	# Ensure float format values:
+    # Identifying # of planning reserve margin constraints for the system
+    columns = names(df)
+    f = s -> startswith(s, "CapRes")
+    res = count(f, columns)
+    first_col = findfirst(f, columns)
+    last_col = findlast(f, columns)
 
-	# Identifying # of planning reserve margin constraints for the system
-	res = count(s -> startswith(String(s), "CapRes"), names(inputs_crm["dfCapRes"]))
-	first_col = findall(s -> s == "CapRes_1", names(inputs_crm["dfCapRes"]))[1]
-	last_col = findall(s -> s == "CapRes_$res", names(inputs_crm["dfCapRes"]))[1]
-	inputs_crm["dfCapRes"] = Matrix{Float64}(inputs_crm["dfCapRes"][:,first_col:last_col])
-	inputs_crm["NCapacityReserveMargin"] = res
+    inputs["dfCapRes"] = Matrix{Float64}(df[:,first_col:last_col])
+    inputs["NCapacityReserveMargin"] = res
 
-	println("Capacity_reserve_margin.csv Successfully Read!")
-
-	return inputs_crm
+    println(filename * " Successfully Read!")
 end
 
 @doc raw"""
-	load_cap_reserve_margin_trans(setup::Dict, inputs_crm::Dict, network_var::DataFrame)
+	load_cap_reserve_margin_trans!(setup::Dict, inputs::Dict, network_var::DataFrame)
 
-Function for reading input parameters related to participation of transmission imports/exports in capacity reserve margin constraint.
+Read input parameters related to participation of transmission imports/exports in capacity reserve margin constraint.
 """
-function load_cap_reserve_margin_trans(setup::Dict, inputs_crm::Dict, network_var::DataFrame)
-	res = inputs_crm["NCapacityReserveMargin"]
+function load_cap_reserve_margin_trans!(setup::Dict, inputs::Dict, network_var::DataFrame)
+    columns = names(network_var)
+    f = s -> startswith(s, "DerateCapRes")
+    my_range = findfirst(f, columns):findlast(f, columns)
+    dfDerateTransCapRes = network_var[:, my_range]
+    inputs["dfDerateTransCapRes"] = Matrix{Float64}(dfDerateTransCapRes[completecases(dfDerateTransCapRes),:])
 
-	first_col_trans_derate = findall(s -> s == "DerateCapRes_1", names(network_var))[1]
-	last_col_trans_derate = findall(s -> s == "DerateCapRes_$res", names(network_var))[1]
-	dfDerateTransCapRes = network_var[:,first_col_trans_derate:last_col_trans_derate]
-	inputs_crm["dfDerateTransCapRes"] = Matrix{Float64}(dfDerateTransCapRes[completecases(dfDerateTransCapRes),:])
-
-	first_col_trans_excl = findall(s -> s == "CapRes_Excl_1", names(network_var))[1]
-	last_col_trans_excl = findall(s -> s == "CapRes_Excl_$res", names(network_var))[1]
-	dfTransCapRes_excl = network_var[:,first_col_trans_excl:last_col_trans_excl]
-	inputs_crm["dfTransCapRes_excl"] = Matrix{Float64}(dfTransCapRes_excl[completecases(dfTransCapRes_excl),:])
-
-	return inputs_crm
+    f = s -> startswith(s, "CapRes_Excl")
+    my_range = findfirst(f, columns):findlast(f, columns)
+    dfTransCapRes_excl = network_var[:, my_range]
+    inputs["dfTransCapRes_excl"] = Matrix{Float64}(dfTransCapRes_excl[completecases(dfTransCapRes_excl),:])
 end

--- a/src/load_inputs/load_cap_reserve_margin.jl
+++ b/src/load_inputs/load_cap_reserve_margin.jl
@@ -21,8 +21,7 @@ Read input parameters related to planning reserve margin constraints
 """
 function load_cap_reserve_margin!(setup::Dict, path::AbstractString, inputs::Dict)
     filename = "Capacity_reserve_margin.csv"
-    # Definition of capacity reserve margin (crm) by locational deliverability area (LDA)
-    df = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    df = load_dataframe(joinpath(path, filename))
 
     # Identifying # of planning reserve margin constraints for the system
     columns = names(df)

--- a/src/load_inputs/load_co2_cap.jl
+++ b/src/load_inputs/load_co2_cap.jl
@@ -21,7 +21,7 @@ Read input parameters related to CO$_2$ emissions cap constraints
 """
 function load_co2_cap!(setup::Dict, path::AbstractString, inputs::Dict)
     filename = "CO2_cap.csv"
-    inputs["dfCO2Cap"] = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    inputs["dfCO2Cap"] = load_dataframe(joinpath(path, filename))
     columns = names(inputs["dfCO2Cap"])
 
     function column_range(heading::AbstractString)

--- a/src/load_inputs/load_dataframe.jl
+++ b/src/load_inputs/load_dataframe.jl
@@ -1,0 +1,63 @@
+"""
+GenX: An Configurable Capacity Expansion Model
+Copyright (C) 2021,  Massachusetts Institute of Technology
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+A complete copy of the GNU General Public License v2 (GPLv2) is available
+in LICENSE.txt.  Users uncompressing this from an archive may not have
+received this license file.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+@doc raw"""
+    load_dataframe(path::AbstractString)
+
+Attempts to load a dataframe from a csv file with the given path.
+If it's not found immediately, it will look for files with a different case (lower/upper)
+in the file's basename.
+"""
+function load_dataframe(path::AbstractString)
+    if isfile(path)
+        return load_dataframe_from_file(path)
+    end
+
+    # not immediately found
+    dir, base = dirname(path), basename(path)
+    target = look_for_file_with_alternate_case(dir, base)
+    load_dataframe_from_file(joinpath(dir, target))
+end
+
+function look_for_file_with_alternate_case(dir, base)
+    lower_base = lowercase(base)
+
+    files_in_dir = readdir(dir)
+    lower_files = map(lowercase, files_in_dir)
+    mapping = Dict(zip(lower_files, files_in_dir))
+
+    if length(mapping) != length(files_in_dir)
+        error("""Files in the directory may have names which differ only by upper/lowercase.
+              This must be corrected.""")
+    end
+
+    FILE_NOT_FOUND = "FILENOTFOUND"
+    target = get(mapping, lower_base, FILE_NOT_FOUND)
+    if target == FILE_NOT_FOUND
+        err_str = """File $base was not found in the directory, "$dir".
+                     Try checking the spelling.
+                     The files in the directory are $files_in_dir"""
+        error(err_str)
+    end
+
+
+    return target
+end
+
+
+function load_dataframe_from_file(path)
+    CSV.read(path, DataFrame, header=1)
+end

--- a/src/load_inputs/load_energy_share_requirement.jl
+++ b/src/load_inputs/load_energy_share_requirement.jl
@@ -22,7 +22,7 @@ Read input parameters related to mimimum energy share requirement constraints
 """
 function load_energy_share_requirement!(setup::Dict, path::AbstractString, inputs::Dict)
     filename = "Energy_share_requirement.csv"
-    df = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    df = load_dataframe(joinpath(path, filename))
 
     f = s -> startswith(s, "ESR")
     columns = names(df)

--- a/src/load_inputs/load_energy_share_requirement.jl
+++ b/src/load_inputs/load_energy_share_requirement.jl
@@ -15,22 +15,22 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_energy_share_requirement(setup::Dict, path::AbstractString, inputs_ESR::Dict)
+    load_energy_share_requirement!(setup::Dict, path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to mimimum energy share requirement constraints (e.g. renewable portfolio standard or clean electricity standard policies)
+Read input parameters related to mimimum energy share requirement constraints
+(e.g. renewable portfolio standard or clean electricity standard policies)
 """
-function load_energy_share_requirement(setup::Dict, path::AbstractString, inputs_ESR::Dict)
-	# Definition of ESR requirements by zone (as % of load)
-	# e.g. any policy requiring a min share of qualifying resources (Renewable Portfolio Standards / Renewable Energy Obligations / Clean Energy Standards etc.)
-	inputs_ESR["dfESR"] = DataFrame(CSV.File(joinpath(path,"Energy_share_requirement.csv"), header=true), copycols=true)
-	# Ensure float format values:
-	ESR = count(s -> startswith(String(s), "ESR"), names(inputs_ESR["dfESR"]))
-	first_col = findall(s -> s == "ESR_1", names(inputs_ESR["dfESR"]))[1]
-	last_col = findall(s -> s == "ESR_$ESR", names(inputs_ESR["dfESR"]))[1]
+function load_energy_share_requirement!(setup::Dict, path::AbstractString, inputs::Dict)
+    filename = "Energy_share_requirement.csv"
+    df = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
 
-	inputs_ESR["dfESR"] = Matrix{Float64}(inputs_ESR["dfESR"][:,first_col:last_col])
-	inputs_ESR["nESR"] = ESR
+    f = s -> startswith(s, "ESR")
+    columns = names(df)
+    first_col = findfirst(f, columns)
+    last_col = findlast(f, columns)
 
-	println("Energy_share_requirement.csv Successfully Read!")
-	return inputs_ESR
+    inputs["dfESR"] = Matrix{Float64}(df[:, first_col:last_col])
+    inputs["nESR"] = count(f, columns)
+
+    println(filename * " Successfully Read!")
 end

--- a/src/load_inputs/load_fuels_data.jl
+++ b/src/load_inputs/load_fuels_data.jl
@@ -15,43 +15,43 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_fuels_data(setup::Dict, path::AbstractString, inputs_fuel::Dict)
+    load_fuels_data!(setup::Dict, path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to fuel costs and CO$_2$ content of fuels
+Read input parameters related to fuel costs and CO$_2$ content of fuels
 """
-function load_fuels_data(setup::Dict, path::AbstractString, inputs_fuel::Dict)
+function load_fuels_data!(setup::Dict, path::AbstractString, inputs::Dict)
 
-	# Fuel related inputs - read in different files depending on if time domain reduction is activated or not
-	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
-	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) # Use Time Domain Reduced data for GenX
-		fuels_in = DataFrame(CSV.File(joinpath(data_directory,"Fuels_data.csv"), header=true), copycols=true)
-	else  # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
-		fuels_in = DataFrame(CSV.File(joinpath(path,"Fuels_data.csv"), header=true), copycols=true)
-	end
+    # Fuel related inputs - read in different files depending on if time domain reduction is activated or not
+    data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
+    if setup["TimeDomainReduction"] == 1  && time_domain_reduced_files_exist(data_directory)
+        my_dir = data_directory
+    else
+        my_dir = path
+    end
+    filename = "Fuels_data.csv"
+    file_path = joinpath(my_dir, filename)
+    fuels_in = DataFrame(CSV.File(file_path, header=true), copycols=true)
 
-	# Fuel costs .&  CO2 emissions rate for each fuel type (stored in dictionary objects)
-	fuels = names(fuels_in)[2:end] # fuel type indexes
-	costs = Matrix(fuels_in[2:end,2:end])
-	# New addition for variable fuel price
-	CO2_content = fuels_in[1,2:end] # tons CO2/MMBtu
-	fuel_costs = Dict{AbstractString,Array{Float64}}()
-	fuel_CO2 = Dict{AbstractString,Float64}()
-	for i = 1:length(fuels)
-		if setup["ParameterScale"] ==1
-			fuel_costs[string(fuels[i])] = costs[:,i]/ModelScalingFactor
-			fuel_CO2[string(fuels[i])] = CO2_content[i]/ModelScalingFactor # kton/MMBTU
-		else
-			fuel_costs[string(fuels[i])] = costs[:,i]
-			fuel_CO2[string(fuels[i])] = CO2_content[i] # ton/MMBTU
-		end
-	end
+    # Fuel costs & CO2 emissions rate for each fuel type
+    fuels = names(fuels_in)[2:end]
+    costs = Matrix(fuels_in[2:end, 2:end])
+    CO2_content = fuels_in[1, 2:end] # tons CO2/MMBtu
+    fuel_costs = Dict{AbstractString, Array{Float64}}()
+    fuel_CO2 = Dict{AbstractString, Float64}()
 
-	inputs_fuel["fuels"] = fuels
-	inputs_fuel["fuel_costs"] = fuel_costs
-	inputs_fuel["fuel_CO2"] = fuel_CO2
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
 
-	println("Fuels_data.csv Successfully Read!")
+    for i = 1:length(fuels)
+            fuel_costs[fuels[i]] = costs[:,i] / scale_factor
+            # fuel_CO2 is kton/MMBTU with scaling, or ton/MMBTU without scaling.
+            fuel_CO2[fuels[i]] = CO2_content[i] / scale_factor
+    end
 
-	return inputs_fuel, fuel_costs, fuel_CO2
+    inputs["fuels"] = fuels
+    inputs["fuel_costs"] = fuel_costs
+    inputs["fuel_CO2"] = fuel_CO2
+
+    println(filename * " Successfully Read!")
+
+    return fuel_costs, fuel_CO2
 end

--- a/src/load_inputs/load_fuels_data.jl
+++ b/src/load_inputs/load_fuels_data.jl
@@ -29,8 +29,7 @@ function load_fuels_data!(setup::Dict, path::AbstractString, inputs::Dict)
         my_dir = path
     end
     filename = "Fuels_data.csv"
-    file_path = joinpath(my_dir, filename)
-    fuels_in = DataFrame(CSV.File(file_path, header=true), copycols=true)
+    fuels_in = load_dataframe(joinpath(my_dir, filename))
 
     # Fuel costs & CO2 emissions rate for each fuel type
     fuels = names(fuels_in)[2:end]

--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -22,7 +22,7 @@ Function for reading input parameters related to electricity generators (plus st
 function load_generators_data!(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
 
     filename = "Generators_data.csv"
-	gen_in = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    gen_in = load_dataframe(joinpath(path, filename))
 
 	# Add Resource IDs after reading to prevent user errors
 	gen_in[!,:R_ID] = 1:length(collect(skipmissing(gen_in[!,1])))

--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -15,23 +15,23 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_generators_data(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
+	load_generators_data!(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
 
 Function for reading input parameters related to electricity generators (plus storage and flexible demand resources)
 """
-function load_generators_data(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
+function load_generators_data!(setup::Dict, path::AbstractString, inputs_gen::Dict, fuel_costs::Dict, fuel_CO2::Dict)
 
-	# Generator related inputs
-	gen_in = DataFrame(CSV.File(joinpath(path, "Generators_data.csv"), header=true), copycols=true)
+    filename = "Generators_data.csv"
+	gen_in = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
 
 	# Add Resource IDs after reading to prevent user errors
-	gen_in[!,:R_ID] = 1:size(collect(skipmissing(gen_in[!,1])),1)
+	gen_in[!,:R_ID] = 1:length(collect(skipmissing(gen_in[!,1])))
 
 	# Store DataFrame of generators/resources input data for use in model
 	inputs_gen["dfGen"] = gen_in
 
 	# Number of resources
-	inputs_gen["G"] = size(collect(skipmissing(gen_in[!,:R_ID])),1)
+	inputs_gen["G"] = length(collect(skipmissing(gen_in[!,:R_ID])))
 
 	# Set indices for internal use
 	G = inputs_gen["G"]   # Number of resources (generators, storage, DR, and DERs)
@@ -251,7 +251,5 @@ function load_generators_data(setup::Dict, path::AbstractString, inputs_gen::Dic
 			#   thus the overall is MTons/GW, and thus inputs_gen["dfGen"][g,:CO2_per_Start] is ton
 		end
 	end
-	println("Generators_data.csv Successfully Read!")
-
-	return inputs_gen
+	println(filename * " Successfully Read!")
 end

--- a/src/load_inputs/load_generators_variability.jl
+++ b/src/load_inputs/load_generators_variability.jl
@@ -29,8 +29,7 @@ function load_generators_variability!(setup::Dict, path::AbstractString, inputs:
         my_dir = path
 	end
     filename = "Generators_variability.csv"
-    file_path = joinpath(my_dir, filename)
-    gen_var = DataFrame(CSV.File(file_path, header=true), copycols=true)
+    gen_var = load_dataframe(joinpath(my_dir, filename))
 
 	# Reorder DataFrame to R_ID order (order provided in Generators_data.csv)
 	select!(gen_var, [:Time_Index; Symbol.(inputs["RESOURCES"]) ])

--- a/src/load_inputs/load_generators_variability.jl
+++ b/src/load_inputs/load_generators_variability.jl
@@ -15,28 +15,28 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_generators_variability(setup::Dict, path::AbstractString, inputs_genvar::Dict)
+	load_generators_variability!(setup::Dict, path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to hourly maximum capacity factors for all generators (plus storage and flexible demand resources)
+Read input parameters related to hourly maximum capacity factors for generators, storage, and flexible demand resources
 """
-function load_generators_variability(setup::Dict, path::AbstractString, inputs_genvar::Dict)
+function load_generators_variability!(setup::Dict, path::AbstractString, inputs::Dict)
 
 	# Hourly capacity factors
-	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) # Use Time Domain Reduced data for GenX
-		gen_var = DataFrame(CSV.File(joinpath(data_directory,"Generators_variability.csv"), header=true), copycols=true)
-	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
-		gen_var = DataFrame(CSV.File(joinpath(path,"Generators_variability.csv"), header=true), copycols=true)
+    if setup["TimeDomainReduction"] == 1  && time_domain_reduced_files_exist(data_directory)
+        my_dir = data_directory
+	else
+        my_dir = path
 	end
+    filename = "Generators_variability.csv"
+    file_path = joinpath(my_dir, filename)
+    gen_var = DataFrame(CSV.File(file_path, header=true), copycols=true)
 
 	# Reorder DataFrame to R_ID order (order provided in Generators_data.csv)
-	select!(gen_var, [:Time_Index; Symbol.(inputs_genvar["RESOURCES"]) ])
+	select!(gen_var, [:Time_Index; Symbol.(inputs["RESOURCES"]) ])
 
 	# Maximum power output and variability of each energy resource
-	inputs_genvar["pP_Max"] = transpose(Matrix{Float64}(gen_var[1:inputs_genvar["T"],2:(inputs_genvar["G"]+1)]))
+	inputs["pP_Max"] = transpose(Matrix{Float64}(gen_var[1:inputs["T"],2:(inputs["G"]+1)]))
 
-	println("Generators_variability.csv Successfully Read!")
-
-	return inputs_genvar
+	println(filename * " Successfully Read!")
 end

--- a/src/load_inputs/load_inputs.jl
+++ b/src/load_inputs/load_inputs.jl
@@ -33,48 +33,48 @@ function load_inputs(setup::Dict,path::AbstractString)
 	inputs = Dict()
 	# Read input data about power network topology, operating and expansion attributes
 	if isfile(joinpath(path,"Network.csv"))
-		inputs, network_var = load_network_data(setup, path, inputs)
+		network_var = load_network_data!(setup, path, inputs)
 	else
 		inputs["Z"] = 1
 		inputs["L"] = 0
 	end
 
 	# Read temporal-resolved load data, and clustering information if relevant
-	inputs = load_load_data(setup, path, inputs)
+	load_load_data!(setup, path, inputs)
 	# Read fuel cost data, including time-varying fuel costs
-	inputs, cost_fuel, CO2_fuel = load_fuels_data(setup, path, inputs)
+	cost_fuel, CO2_fuel = load_fuels_data!(setup, path, inputs)
 	# Read in generator/resource related inputs
-	inputs = load_generators_data(setup, path, inputs, cost_fuel, CO2_fuel)
+	load_generators_data!(setup, path, inputs, cost_fuel, CO2_fuel)
 	# Read in generator/resource availability profiles
-	inputs = load_generators_variability(setup, path, inputs)
+	load_generators_variability!(setup, path, inputs)
 
 	if setup["CapacityReserveMargin"]==1
-		inputs = load_cap_reserve_margin(setup, path, inputs)
+		load_cap_reserve_margin!(setup, path, inputs)
 		if inputs["Z"] >1
-			inputs = load_cap_reserve_margin_trans(setup, inputs,network_var)
+			load_cap_reserve_margin_trans!(setup, inputs, network_var)
 		end
 	end
 
 	# Read in general configuration parameters for reserves (resource-specific reserve parameters are read in generators_data())
 	if setup["Reserves"]==1
-		inputs = load_reserves(setup, path, inputs)
+		load_reserves!(setup, path, inputs)
 	end
 
 	if setup["MinCapReq"] == 1
-		inputs = load_minimum_capacity_requirement(path, inputs, setup)
+		load_minimum_capacity_requirement!(path, inputs, setup)
 	end
 
 	if setup["EnergyShareRequirement"]==1
-		inputs = load_energy_share_requirement(setup, path, inputs)
+		load_energy_share_requirement!(setup, path, inputs)
 	end
 
 	if setup["CO2Cap"] >= 1
-		inputs = load_co2_cap(setup, path, inputs)
+		load_co2_cap!(setup, path, inputs)
 	end
 
 	# Read in mapping of modeled periods to representative periods
 	if is_period_map_necessary(setup, path, inputs) && is_period_map_exist(setup, path, inputs)
-		inputs = load_period_map(setup, path, inputs)
+		load_period_map!(setup, path, inputs)
 	end
 
 	println("CSV Files Successfully Read In From $path")

--- a/src/load_inputs/load_load_data.jl
+++ b/src/load_inputs/load_load_data.jl
@@ -29,8 +29,7 @@ function load_load_data!(setup::Dict, path::AbstractString, inputs::Dict)
         my_dir = path
 	end
     filename = "Load_data.csv"
-    file_path = joinpath(my_dir, filename)
-    load_in = DataFrame(CSV.File(file_path, header=true), copycols=true)
+    load_in = load_dataframe(joinpath(my_dir, filename))
 
     as_vector(col::Symbol) = collect(skipmissing(load_in[!, col]))
 

--- a/src/load_inputs/load_load_data.jl
+++ b/src/load_inputs/load_load_data.jl
@@ -15,109 +15,80 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_data(setup::Dict, path::AbstractString, inputs_load::Dict)
+	load_load_data!(setup::Dict, path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to electricity load (demand)
+Read input parameters related to electricity load (demand)
 """
-function load_load_data(setup::Dict, path::AbstractString, inputs_load::Dict)
+function load_load_data!(setup::Dict, path::AbstractString, inputs::Dict)
 
 	# Load related inputs
-	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) # Use Time Domain Reduced data for GenX
-		load_in = DataFrame(CSV.File(joinpath(data_directory,"Load_data.csv"), header=true), copycols=true)
-	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
-		load_in = DataFrame(CSV.File(joinpath(path,"Load_data.csv"), header=true), copycols=true)
+    if setup["TimeDomainReduction"] == 1  && time_domain_reduced_files_exist(data_directory)
+        my_dir = data_directory
+	else
+        my_dir = path
 	end
+    filename = "Load_data.csv"
+    file_path = joinpath(my_dir, filename)
+    load_in = DataFrame(CSV.File(file_path, header=true), copycols=true)
 
+    as_vector(col::Symbol) = collect(skipmissing(load_in[!, col]))
 
 	# Number of time steps (periods)
-	inputs_load["T"] = size(collect(skipmissing(load_in[!,:Time_Index])),1)
+    T = length(as_vector(:Time_Index))
 	# Number of demand curtailment/lost load segments
-	inputs_load["SEG"]=size(collect(skipmissing(load_in[!,:Demand_Segment])),1)
+    SEG = length(as_vector(:Demand_Segment))
 
 	## Set indices for internal use
-	T = inputs_load["T"]   # Total number of time steps (hours)
-	Z = inputs_load["Z"]   # Number of zones
-	L = inputs_load["L"]   # Number of lines
+    inputs["T"] = T
+    inputs["SEG"] = SEG
+	Z = inputs["Z"]   # Number of zones
 
-	inputs_load["omega"] = zeros(Float64, T) # weights associated with operational sub-period in the model - sum of weight = 8760
-	inputs_load["REP_PERIOD"] = 1   # Number of periods initialized
-	inputs_load["H"] = 1   # Number of sub-periods within each period
+	inputs["omega"] = zeros(Float64, T) # weights associated with operational sub-period in the model - sum of weight = 8760
+	inputs["REP_PERIOD"] = 1   # Number of periods initialized
+	inputs["H"] = 1   # Number of sub-periods within each period
 
 	if setup["OperationWrapping"]==0 # Modeling full year chronologically at hourly resolution
-		# Total number of subtime periods
-		inputs_load["REP_PERIOD"] = 1
 		# Simple scaling factor for number of subperiods
-		inputs_load["omega"][:] .= 1 #changes all rows of inputs["omega"] from 0.0 to 1.0
+		inputs["omega"] .= 1 #changes all rows of inputs["omega"] from 0.0 to 1.0
 	elseif setup["OperationWrapping"]==1
 		# Weights for each period - assumed same weights for each sub-period within a period
-		inputs_load["Weights"] = collect(skipmissing(load_in[!,:Sub_Weights])) # Weights each period
+		inputs["Weights"] = as_vector(:Sub_Weights) # Weights each period
 
 		# Total number of periods and subperiods
-		inputs_load["REP_PERIOD"] = convert(Int16, collect(skipmissing(load_in[!,:Rep_Periods]))[1])
-		inputs_load["H"] = convert(Int64, collect(skipmissing(load_in[!,:Timesteps_per_Rep_Period]))[1])
+		inputs["REP_PERIOD"] = convert(Int16, as_vector(:Rep_Periods)[1])
+		inputs["H"] = convert(Int64, as_vector(:Timesteps_per_Rep_Period)[1])
 
 		# Creating sub-period weights from weekly weights
-		for w in 1:inputs_load["REP_PERIOD"]
-			for h in 1:inputs_load["H"]
-				t = inputs_load["H"]*(w-1)+h
-				inputs_load["omega"][t] = inputs_load["Weights"][w]/inputs_load["H"]
+		for w in 1:inputs["REP_PERIOD"]
+			for h in 1:inputs["H"]
+				t = inputs["H"]*(w-1)+h
+				inputs["omega"][t] = inputs["Weights"][w]/inputs["H"]
 			end
 		end
 	end
 
 	# Create time set steps indicies
-	inputs_load["hours_per_subperiod"] = div.(T,inputs_load["REP_PERIOD"]) # total number of hours per subperiod
-	hours_per_subperiod = inputs_load["hours_per_subperiod"] # set value for internal use
+	inputs["hours_per_subperiod"] = div.(T,inputs["REP_PERIOD"]) # total number of hours per subperiod
+	hours_per_subperiod = inputs["hours_per_subperiod"] # set value for internal use
 
-	inputs_load["START_SUBPERIODS"] = 1:hours_per_subperiod:T 	# set of indexes for all time periods that start a subperiod (e.g. sample day/week)
-	inputs_load["INTERIOR_SUBPERIODS"] = setdiff(1:T,inputs_load["START_SUBPERIODS"]) # set of indexes for all time periods that do not start a subperiod
+	inputs["START_SUBPERIODS"] = 1:hours_per_subperiod:T 	# set of indexes for all time periods that start a subperiod (e.g. sample day/week)
+	inputs["INTERIOR_SUBPERIODS"] = setdiff(1:T, inputs["START_SUBPERIODS"]) # set of indexes for all time periods that do not start a subperiod
 
 	# Demand in MW for each zone
 	#println(names(load_in))
 	start = findall(s -> s == "Load_MW_z1", names(load_in))[1] #gets the starting column number of all the columns, with header "Load_MW_z1"
-	if setup["ParameterScale"] ==1  # Parameter scaling turned on
-		# Max value of non-served energy
-		inputs_load["Voll"] = collect(skipmissing(load_in[!,:Voll])) /ModelScalingFactor # convert from $/MWh $ million/GWh (assuming objective is divided by 1000)
-		# Demand in MW
-		inputs_load["pD"] =Matrix(load_in[1:inputs_load["T"],start:start-1+inputs_load["Z"]])/ModelScalingFactor  # convert to GW
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
+    # Max value of non-served energy
+    inputs["Voll"] = as_vector(:Voll) / scale_factor # convert from $/MWh $ million/GWh (assuming objective is divided by 1000)
+    # Demand in MW
+    inputs["pD"] =Matrix(load_in[1:T, start:start+Z-1]) / scale_factor  # convert to GW
 
-	else # No scaling
-		# Max value of non-served energy
-		inputs_load["Voll"] = collect(skipmissing(load_in[!,:Voll]))
-		# Demand in MW
-		inputs_load["pD"] =Matrix(load_in[1:inputs_load["T"],start:start-1+inputs_load["Z"]]) #form a matrix with columns as the different zonal load MW values and rows as the hours
-	end
+	# Cost of non-served energy/demand curtailment
+    # Cost of each segment reported as a fraction of value of non-served energy - scaled implicitly
+    inputs["pC_D_Curtail"] = as_vector(:Cost_of_Demand_Curtailment_per_MW) * inputs["Voll"][1]
+    # Maximum hourly demand curtailable as % of the max demand (for each segment)
+    inputs["pMax_D_Curtail"] = as_vector(:Max_Demand_Curtailment)
 
-	#if setup["TimeDomainReduction"] ==1 # Used in time_domain_reduction
-	#	inputs_load["TimestepsPerPeriod"] = collect(skipmissing(load_in[!,:Timesteps_per_Rep_Period]))[1]
-	#	inputs_load["UseExtremePeriods"] = collect(skipmissing(load_in[!,:UseExtremePeriods]))[1]
-	#	inputs_load["MinPeriods"] = collect(skipmissing(load_in[!,:MinPeriods]))[1]
-	#	inputs_load["MaxPeriods"] = collect(skipmissing(load_in[!,:MaxPeriods]))[1]
-	#	inputs_load["IterativelyAddPeriods"] = collect(skipmissing(load_in[!,:IterativelyAddPeriods]))[1]
-	#	inputs_load["IterateMethod"] = collect(skipmissing(load_in[!,:IterateMethod]))[1]
-	#	inputs_load["ClusterMethod"] = collect(skipmissing(load_in[!,:ClusterMethod]))[1]
-	#	inputs_load["Threshold"] = collect(skipmissing(load_in[!,:Threshold]))[1]
-	#	inputs_load["nReps"] = collect(skipmissing(load_in[!,:nReps]))[1]
-	#	inputs_load["ScalingMethod"] = collect(skipmissing(load_in[!,:ScalingMethod]))[1]
-	#	inputs_load["LoadWeight"] = collect(skipmissing(load_in[!,:LoadWeight]))[1]
-	#	inputs_load["ClusterFuelPrices"] = collect(skipmissing(load_in[!,:ClusterFuelPrices]))[1]
-	#	inputs_load["WeightTotal"] = collect(skipmissing(load_in[!,:WeightTotal]))[1]
-	#end
-
-	# Cost of non-served energy/demand curtailment (for each segment)
-	SEG = inputs_load["SEG"]  # Number of demand segments
-	inputs_load["pC_D_Curtail"] = zeros(SEG)
-	inputs_load["pMax_D_Curtail"] = zeros(SEG)
-	for s in 1:SEG
-		# Cost of each segment reported as a fraction of value of non-served energy - scaled implicitly
-		inputs_load["pC_D_Curtail"][s] = collect(skipmissing(load_in[!,:Cost_of_Demand_Curtailment_per_MW]))[s]*inputs_load["Voll"][1]
-		# Maximum hourly demand curtailable as % of the max demand (for each segment)
-		inputs_load["pMax_D_Curtail"][s] = collect(skipmissing(load_in[!,:Max_Demand_Curtailment]))[s]
-	end
-
-	println("Load_data.csv Successfully Read!")
-
-	return inputs_load
+	println(filename * " Successfully Read!")
 end

--- a/src/load_inputs/load_minimum_capacity_requirement.jl
+++ b/src/load_inputs/load_minimum_capacity_requirement.jl
@@ -21,7 +21,7 @@ Read input parameters related to mimimum capacity requirement constraints (e.g. 
 """
 function load_minimum_capacity_requirement!(path::AbstractString, inputs::Dict, setup::Dict)
     filename = "Minimum_capacity_requirement.csv"
-    df = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    df = load_dataframe(joinpath(path, filename))
     NumberOfMinCapReqs = length(df[!,:MinCapReqConstraint])
     inputs["NumberOfMinCapReqs"] = NumberOfMinCapReqs
     inputs["MinCapReq"] = df[!,:Min_MW]

--- a/src/load_inputs/load_minimum_capacity_requirement.jl
+++ b/src/load_inputs/load_minimum_capacity_requirement.jl
@@ -15,18 +15,18 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_minimum_capacity_requirement(path::AbstractString, inputs::Dict, setup::Dict)
+    load_minimum_capacity_requirement!(path::AbstractString, inputs::Dict, setup::Dict)
 
-Function for reading input parameters related to mimimum capacity requirement constraints (e.g. technology specific deployment mandates)
+Read input parameters related to mimimum capacity requirement constraints (e.g. technology specific deployment mandates)
 """
-function load_minimum_capacity_requirement(path::AbstractString, inputs::Dict, setup::Dict)
-	MinCapReq = DataFrame(CSV.File(joinpath(path, "Minimum_capacity_requirement.csv"), header=true), copycols=true)
-	NumberOfMinCapReqs = size(collect(skipmissing(MinCapReq[!,:MinCapReqConstraint])),1)
-	inputs["NumberOfMinCapReqs"] = NumberOfMinCapReqs
-	inputs["MinCapReq"] = MinCapReq[!,:Min_MW]
-	if setup["ParameterScale"] == 1
-		inputs["MinCapReq"] = inputs["MinCapReq"]/ModelScalingFactor # Convert to GW
-	end
-	println("Minimum_capacity_requirement.csv Successfully Read!")
-	return inputs
+function load_minimum_capacity_requirement!(path::AbstractString, inputs::Dict, setup::Dict)
+    filename = "Minimum_capacity_requirement.csv"
+    df = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    NumberOfMinCapReqs = length(df[!,:MinCapReqConstraint])
+    inputs["NumberOfMinCapReqs"] = NumberOfMinCapReqs
+    inputs["MinCapReq"] = df[!,:Min_MW]
+    if setup["ParameterScale"] == 1
+        inputs["MinCapReq"] /= ModelScalingFactor # Convert to GW
+    end
+    println(filename * " Successfully Read!")
 end

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -25,7 +25,7 @@ function load_network_data!(setup::Dict, path::AbstractString, inputs_nw::Dict)
     scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
 
     filename = "Network.csv"
-    network_var = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    network_var = load_dataframe(joinpath(path, filename))
 
     as_vector(col::Symbol) = collect(skipmissing(network_var[!, col]))
     to_floats(col::Symbol) = convert(Array{Float64}, as_vector(col))

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -20,12 +20,12 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 Function for reading input parameters related to the electricity transmission network
 """
 #DEV NOTE:  add DC power flow related parameter inputs in a subsequent commit
-function load_network_data(setup::Dict, path::AbstractString, inputs_nw::Dict)
+function load_network_data!(setup::Dict, path::AbstractString, inputs_nw::Dict)
 
     scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
 
-    # Network zones inputs and Network topology inputs
-    network_var = DataFrame(CSV.File(joinpath(path,"Network.csv"), header=true), copycols=true)
+    filename = "Network.csv"
+    network_var = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
 
     as_vector(col::Symbol) = collect(skipmissing(network_var[!, col]))
     to_floats(col::Symbol) = convert(Array{Float64}, as_vector(col))
@@ -96,9 +96,9 @@ function load_network_data(setup::Dict, path::AbstractString, inputs_nw::Dict)
         inputs_nw["NO_EXPANSION_LINES"] = findall(inputs_nw["pMax_Line_Reinforcement"].<0)
     end
 
-    println("Network.csv Successfully Read!")
+    println(filename * " Successfully Read!")
 
-    return inputs_nw, network_var
+    return network_var
 end
 
 @doc raw"""

--- a/src/load_inputs/load_period_map.jl
+++ b/src/load_inputs/load_period_map.jl
@@ -28,7 +28,7 @@ function load_period_map!(setup::Dict, path::AbstractString, inputs::Dict)
 		my_dir = path
 	end
 	file_path = joinpath(my_dir, period_map)
-	inputs["Period_Map"] = DataFrame(CSV.File(file_path, header=true), copycols=true)
+    inputs["Period_Map"] = load_dataframe(file_path)
 
 	println(period_map * " Successfully Read!")
 end

--- a/src/load_inputs/load_period_map.jl
+++ b/src/load_inputs/load_period_map.jl
@@ -15,11 +15,11 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_period_map(setup::Dict, path::AbstractString, inputs::Dict)
+	load_period_map!(setup::Dict, path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to mapping of representative time periods to full chronological time series
+Read input parameters related to mapping of representative time periods to full chronological time series
 """
-function load_period_map(setup::Dict, path::AbstractString, inputs::Dict)
+function load_period_map!(setup::Dict, path::AbstractString, inputs::Dict)
 	period_map = "Period_map.csv"
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
 	if setup["TimeDomainReduction"] == 1 && isfile(joinpath(data_directory, period_map))  # Use Time Domain Reduced data for GenX
@@ -31,6 +31,4 @@ function load_period_map(setup::Dict, path::AbstractString, inputs::Dict)
 	inputs["Period_Map"] = DataFrame(CSV.File(file_path, header=true), copycols=true)
 
 	println(period_map * " Successfully Read!")
-
-	return inputs
 end

--- a/src/load_inputs/load_reserves.jl
+++ b/src/load_inputs/load_reserves.jl
@@ -21,7 +21,7 @@ Read input parameters related to frequency regulation and operating reserve requ
 """
 function load_reserves!(setup::Dict, path::AbstractString, inputs::Dict)
     filename = "Reserves.csv"
-	res_in = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
+    res_in = load_dataframe(joinpath(path, filename))
 
 	# Regulation requirement as a percent of hourly load; here load is the total across all model zones
 	inputs["pReg_Req_Load"] = float(res_in[1,:Reg_Req_Percent_Load])

--- a/src/load_inputs/load_reserves.jl
+++ b/src/load_inputs/load_reserves.jl
@@ -15,50 +15,45 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	load_reserves(setup::Dict,path::AbstractString, inputs_res::Dict)
+	load_reserves!(setup::Dict,path::AbstractString, inputs::Dict)
 
-Function for reading input parameters related to frequency regulation and operating reserve requirements
+Read input parameters related to frequency regulation and operating reserve requirements
 """
-function load_reserves(setup::Dict,path::AbstractString, inputs_res::Dict)
-	##Reserve inputs
-	res_in = DataFrame(CSV.File(joinpath(path, "Reserves.csv"), header=true), copycols=true)
+function load_reserves!(setup::Dict, path::AbstractString, inputs::Dict)
+    filename = "Reserves.csv"
+	res_in = DataFrame(CSV.File(joinpath(path, filename), header=true), copycols=true)
 
 	# Regulation requirement as a percent of hourly load; here load is the total across all model zones
-	inputs_res["pReg_Req_Load"] = convert(Float64, res_in[1,:Reg_Req_Percent_Load])
+	inputs["pReg_Req_Load"] = float(res_in[1,:Reg_Req_Percent_Load])
 	# Regulation requirement as a percent of hourly wind and solar generation (summed across all model zones)
-	inputs_res["pReg_Req_VRE"] = convert(Float64, res_in[1,:Reg_Req_Percent_VRE])
+	inputs["pReg_Req_VRE"] = float(res_in[1,:Reg_Req_Percent_VRE])
 	# Spinning up reserve requirement as a percent of hourly load (which is summed across all zones)
-	inputs_res["pRsv_Req_Load"] = convert(Float64, res_in[1,:Rsv_Req_Percent_Load])
+	inputs["pRsv_Req_Load"] = float(res_in[1,:Rsv_Req_Percent_Load])
 	# Spinning up reserve requirement as a percent of hourly wind and solar generation (which is summed across all zones)
-	inputs_res["pRsv_Req_VRE"] = convert(Float64, res_in[1,:Rsv_Req_Percent_VRE])
+	inputs["pRsv_Req_VRE"] = float(res_in[1,:Rsv_Req_Percent_VRE])
 
-	if setup["ParameterScale"] == 1  # Parameter scaling turned on - adjust values of subset of parameter values
-		# Penalty for not meeting hourly spinning reserve requirement
-		inputs_res["pC_Rsv_Penalty"] = convert(Float64, res_in[1,:Unmet_Rsv_Penalty_Dollar_per_MW])/ModelScalingFactor # convert to million $/GW with objective function in millions
-		inputs_res["pStatic_Contingency"] = convert(Float64, res_in[1,:Static_Contingency_MW])/ModelScalingFactor # convert to GW
-	else
-		# Penalty for not meeting hourly spinning reserve requirement
-		inputs_res["pC_Rsv_Penalty"] = convert(Float64, res_in[1,:Unmet_Rsv_Penalty_Dollar_per_MW])
-		inputs_res["pStatic_Contingency"] = convert(Float64, res_in[1,:Static_Contingency_MW])
-	end
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
+
+    # Penalty for not meeting hourly spinning reserve requirement
+    inputs["pC_Rsv_Penalty"] = float(res_in[1,:Unmet_Rsv_Penalty_Dollar_per_MW]) / scale_factor # convert to million $/GW with objective function in millions
+    inputs["pStatic_Contingency"] = float(res_in[1,:Static_Contingency_MW]) / scale_factor # convert to GW
+
 	if setup["UCommit"] >= 1
-		inputs_res["pDynamic_Contingency"] = convert(Int8, res_in[1,:Dynamic_Contingency] )
+		inputs["pDynamic_Contingency"] = convert(Int8, res_in[1,:Dynamic_Contingency] )
 		# Set BigM value used for dynamic contingencies cases to be largest possible cluster size
 		# Note: this BigM value is only relevant for units in the COMMIT set. See reserves.jl for details on implementation of dynamic contingencies
-		if inputs_res["pDynamic_Contingency"] > 0
-			inputs_res["pContingency_BigM"] = zeros(Float64, inputs_res["G"])
-			for y in inputs_res["COMMIT"]
-				inputs_res["pContingency_BigM"][y] = inputs_res["dfGen"][y,:Max_Cap_MW]
+		if inputs["pDynamic_Contingency"] > 0
+			inputs["pContingency_BigM"] = zeros(Float64, inputs["G"])
+			for y in inputs["COMMIT"]
+				inputs["pContingency_BigM"][y] = inputs["dfGen"][y,:Max_Cap_MW]
 				# When Max_Cap_MW == -1, there is no limit on capacity size
-				if inputs_res["pContingency_BigM"][y] < 0
+				if inputs["pContingency_BigM"][y] < 0
 					# NOTE: this effectively acts as a maximum cluster size when not otherwise specified, adjust accordingly
-					inputs_res["pContingency_BigM"][y] = 5000*inputs_res["dfGen"][y,:Cap_Size]
+					inputs["pContingency_BigM"][y] = 5000*inputs["dfGen"][y,:Cap_Size]
 				end
 			end
 		end
 	end
 
-	println("Reserves.csv Successfully Read!")
-
-	return inputs_res
+	println(filename * " Successfully Read!")
 end

--- a/src/multi_stage/write_multi_stage_capacities_charge.jl
+++ b/src/multi_stage/write_multi_stage_capacities_charge.jl
@@ -31,7 +31,6 @@ function write_multi_stage_capacities_charge(outpath::String, settings_d::Dict)
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        #capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
         capacities_d[p] = load_dataframe(joinpath(inpath, "capacity.csv"))
     end
 

--- a/src/multi_stage/write_multi_stage_capacities_charge.jl
+++ b/src/multi_stage/write_multi_stage_capacities_charge.jl
@@ -31,7 +31,8 @@ function write_multi_stage_capacities_charge(outpath::String, settings_d::Dict)
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
+        #capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
+        capacities_d[p] = load_dataframe(joinpath(inpath, "capacity.csv"))
     end
 
     # Set first column of DataFrame as resource names from the first stage

--- a/src/multi_stage/write_multi_stage_capacities_discharge.jl
+++ b/src/multi_stage/write_multi_stage_capacities_discharge.jl
@@ -31,7 +31,8 @@ function write_multi_stage_capacities_discharge(outpath::String, settings_d::Dic
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
+        #capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
+        capacities_d[p] = load_dataframe(joinpath(inpath, "capacity.csv"))
     end
 
     # Set first column of DataFrame as resource names from the first stage

--- a/src/multi_stage/write_multi_stage_capacities_discharge.jl
+++ b/src/multi_stage/write_multi_stage_capacities_discharge.jl
@@ -31,7 +31,6 @@ function write_multi_stage_capacities_discharge(outpath::String, settings_d::Dic
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        #capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
         capacities_d[p] = load_dataframe(joinpath(inpath, "capacity.csv"))
     end
 

--- a/src/multi_stage/write_multi_stage_capacities_energy.jl
+++ b/src/multi_stage/write_multi_stage_capacities_energy.jl
@@ -31,7 +31,8 @@ function write_multi_stage_capacities_energy(outpath::String, settings_d::Dict)
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
+        #capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
+        capacities_d[p] = load_dataframe(joinpath(inpath, "capacity.csv"))
     end
 
     # Set first column of DataFrame as resource names from the first stage

--- a/src/multi_stage/write_multi_stage_capacities_energy.jl
+++ b/src/multi_stage/write_multi_stage_capacities_energy.jl
@@ -31,7 +31,6 @@ function write_multi_stage_capacities_energy(outpath::String, settings_d::Dict)
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        #capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "capacity.csv"), header=true), copycols=true)
         capacities_d[p] = load_dataframe(joinpath(inpath, "capacity.csv"))
     end
 

--- a/src/multi_stage/write_multi_stage_costs.jl
+++ b/src/multi_stage/write_multi_stage_costs.jl
@@ -34,7 +34,8 @@ function write_multi_stage_costs(outpath::String, settings_d::Dict, inputs_dict:
     costs_d = Dict()
     for p in 1:num_stages
         cur_path = joinpath(outpath, "Results_p$p")
-        costs_d[p] = DataFrame(CSV.File(joinpath(cur_path, "costs.csv"), header=true), copycols=true)
+        #costs_d[p] = DataFrame(CSV.File(joinpath(cur_path, "costs.csv"), header=true), copycols=true)
+        costs_d[p] = load_dataframe(joinpath(cur_path, "costs.csv"))
     end
 
     OPEXMULTS = [inputs_dict[j]["OPEXMULT"] for j in 1:num_stages] # Stage-wise OPEX multipliers to count multiple years between two model stages

--- a/src/multi_stage/write_multi_stage_costs.jl
+++ b/src/multi_stage/write_multi_stage_costs.jl
@@ -34,7 +34,6 @@ function write_multi_stage_costs(outpath::String, settings_d::Dict, inputs_dict:
     costs_d = Dict()
     for p in 1:num_stages
         cur_path = joinpath(outpath, "Results_p$p")
-        #costs_d[p] = DataFrame(CSV.File(joinpath(cur_path, "costs.csv"), header=true), copycols=true)
         costs_d[p] = load_dataframe(joinpath(cur_path, "costs.csv"))
     end
 

--- a/src/multi_stage/write_multi_stage_network_expansion.jl
+++ b/src/multi_stage/write_multi_stage_network_expansion.jl
@@ -31,7 +31,6 @@ function write_multi_stage_network_expansion(outpath::String, settings_d::Dict)
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        #trans_capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "network_expansion.csv"), header=true), copycols=true)
         trans_capacities_d[p] = load_dataframe(joinpath(inpath, "network_expansion.csv"))
     end
 

--- a/src/multi_stage/write_multi_stage_network_expansion.jl
+++ b/src/multi_stage/write_multi_stage_network_expansion.jl
@@ -31,7 +31,8 @@ function write_multi_stage_network_expansion(outpath::String, settings_d::Dict)
 
     for p in 1:num_stages
         inpath = joinpath(outpath, "Results_p$p")
-        trans_capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "network_expansion.csv"), header=true), copycols=true)
+        #trans_capacities_d[p] = DataFrame(CSV.File(joinpath(inpath, "network_expansion.csv"), header=true), copycols=true)
+        trans_capacities_d[p] = load_dataframe(joinpath(inpath, "network_expansion.csv"))
     end
 
     # Set first column of output DataFrame as line IDs

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -32,6 +32,7 @@ using StatsBase
 using Clustering
 using Distances
 using CSV
+using GenX
 
 
 @doc raw"""
@@ -976,7 +977,7 @@ function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
 
                 # Save output data to stage-specific locations
                 ### TDR_Results/Load_data_clustered.csv
-                load_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", "Inputs_p$per", "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+                load_in = load_dataframe(joinpath(inpath, "Inputs", "Inputs_p$per", "Load_data.csv"))
                 load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
                 load_in[1:length(Stage_Weights[per]),:Sub_Weights] .= Stage_Weights[per]
                 load_in[!,:Rep_Periods][1] = length(Stage_Weights[per])
@@ -1008,7 +1009,7 @@ function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
                 CSV.write(joinpath(inpath, "Inputs", Stage_Outfiles[per]["GVar"]), GVOutputData, header=NewGVColNames)
 
                 ### TDR_Results/Fuels_data.csv
-                fuel_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", "Inputs_p$per", "Fuels_data.csv"), header=true), copycols=true)
+                fuel_in = load_dataframe(joinpath(inpath, "Inputs", "Inputs_p$per", "Fuels_data.csv"))
                 select!(fuel_in, Not(:Time_Index))
                 SepFirstRow = DataFrame(fuel_in[1, :])
                 NewFuelOutput = vcat(SepFirstRow, FPOutputData)
@@ -1034,7 +1035,7 @@ function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
             mkpath(joinpath(inpath,"Inputs",input_stage_directory, TimeDomainReductionFolder))
 
             ### TDR_Results/Load_data.csv
-            load_in = DataFrame(CSV.File(joinpath(inpath, "Inputs", input_stage_directory, "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+            load_in = load_dataframe(joinpath(inpath, "Inputs", input_stage_directory, "Load_data.csv"))
             load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
             load_in[1:length(W),:Sub_Weights] .= W
             load_in[!,:Rep_Periods][1] = length(W)
@@ -1068,7 +1069,7 @@ function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
 
             ### TDR_Results/Fuels_data.csv
 
-            fuel_in = DataFrame(CSV.File(joinpath(inpath,"Inputs",input_stage_directory,"Fuels_data.csv"), header=true), copycols=true)
+            fuel_in = load_dataframe(joinpath(inpath,"Inputs",input_stage_directory,"Fuels_data.csv"))
             select!(fuel_in, Not(:Time_Index))
             SepFirstRow = DataFrame(fuel_in[1, :])
             NewFuelOutput = vcat(SepFirstRow, FPOutputData)
@@ -1090,7 +1091,7 @@ function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
         mkpath(joinpath(inpath, TimeDomainReductionFolder))
 
         ### TDR_Results/Load_data.csv
-        load_in = DataFrame(CSV.File(joinpath(inpath, "Load_data.csv"), header=true), copycols=true) #Setting header to false doesn't take the names of the columns; not including it, not including copycols, or, setting copycols to false has no effect
+        load_in = load_dataframe(joinpath(inpath, "Load_data.csv"))
         load_in[!,:Sub_Weights] = load_in[!,:Sub_Weights] * 1.
         load_in[1:length(W),:Sub_Weights] .= W
         load_in[!,:Rep_Periods][1] = length(W)
@@ -1124,7 +1125,7 @@ function cluster_inputs(inpath, settings_path, mysetup, stage_id=-99, v=false)
 
         ### TDR_Results/Fuels_data.csv
 
-        fuel_in = DataFrame(CSV.File(joinpath(inpath, "Fuels_data.csv"), header=true), copycols=true)
+        fuel_in = load_dataframe(joinpath(inpath, "Fuels_data.csv"))
         select!(fuel_in, Not(:Time_Index))
         SepFirstRow = DataFrame(fuel_in[1, :])
         NewFuelOutput = vcat(SepFirstRow, FPOutputData)


### PR DESCRIPTION
Add a function to load a dataframe from our common sort of CSV file. This helps DRY with regard to dataframe loading settings, making code easier to read and ensuring the same options (header=1, copycols=false) are applied everywhere. Also, if we want to make dataframe loading smarter, now there's one centralized place to do it.

This commit also adds a feature that CSV files of different case can also be loaded, addressing #288 . It does not look for folders or yaml files with different cases. @RuaridhMacd it would be great if you could test this on a case-insensitive file system. 
The current implementation is sort of a minimum-working-example, it could certainly be better.