### PR TITLE
Add function for extracting matrix from a df

### DIFF
--- a/src/load_inputs/load_cap_reserve_margin.jl
+++ b/src/load_inputs/load_cap_reserve_margin.jl
@@ -23,15 +23,9 @@ function load_cap_reserve_margin!(setup::Dict, path::AbstractString, inputs::Dic
     filename = "Capacity_reserve_margin.csv"
     df = load_dataframe(joinpath(path, filename))
 
-    # Identifying # of planning reserve margin constraints for the system
-    columns = names(df)
-    f = s -> startswith(s, "CapRes")
-    res = count(f, columns)
-    first_col = findfirst(f, columns)
-    last_col = findlast(f, columns)
-
-    inputs["dfCapRes"] = Matrix{Float64}(df[:,first_col:last_col])
-    inputs["NCapacityReserveMargin"] = res
+    mat = extract_matrix_from_dataframe(df, "CapRes")
+    inputs["dfCapRes"] = mat
+    inputs["NCapacityReserveMargin"] = size(mat, 2)
 
     println(filename * " Successfully Read!")
 end
@@ -42,14 +36,9 @@ end
 Read input parameters related to participation of transmission imports/exports in capacity reserve margin constraint.
 """
 function load_cap_reserve_margin_trans!(setup::Dict, inputs::Dict, network_var::DataFrame)
-    columns = names(network_var)
-    f = s -> startswith(s, "DerateCapRes")
-    my_range = findfirst(f, columns):findlast(f, columns)
-    dfDerateTransCapRes = network_var[:, my_range]
-    inputs["dfDerateTransCapRes"] = Matrix{Float64}(dfDerateTransCapRes[completecases(dfDerateTransCapRes),:])
+    mat = extract_matrix_from_dataframe(network_var, "DerateCapRes")
+    inputs["dfDerateTransCapRes"] = mat
 
-    f = s -> startswith(s, "CapRes_Excl")
-    my_range = findfirst(f, columns):findlast(f, columns)
-    dfTransCapRes_excl = network_var[:, my_range]
-    inputs["dfTransCapRes_excl"] = Matrix{Float64}(dfTransCapRes_excl[completecases(dfTransCapRes_excl),:])
+    mat = extract_matrix_from_dataframe(network_var, "CapRes_Excl")
+    inputs["dfTransCapRes_excl"] = mat
 end

--- a/src/load_inputs/load_co2_cap.jl
+++ b/src/load_inputs/load_co2_cap.jl
@@ -21,35 +21,29 @@ Read input parameters related to CO$_2$ emissions cap constraints
 """
 function load_co2_cap!(setup::Dict, path::AbstractString, inputs::Dict)
     filename = "CO2_cap.csv"
-    inputs["dfCO2Cap"] = load_dataframe(joinpath(path, filename))
-    columns = names(inputs["dfCO2Cap"])
+    df = load_dataframe(joinpath(path, filename))
 
-    function column_range(heading::AbstractString)
-        f = s -> startswith(s, heading)
-        findfirst(f, columns):findlast(f, columns)
-    end
-
-    my_range = column_range("CO_2_Cap_Zone")
-
-    inputs["dfCO2CapZones"] = Matrix{Float64}(inputs["dfCO2Cap"][:, my_range])
-    inputs["NCO2Cap"] = length(my_range)
+    inputs["dfCO2Cap"] = df
+    mat = extract_matrix_from_dataframe(df, "CO_2_Cap_Zone")
+    inputs["dfCO2CapZones"] = mat
+    inputs["NCO2Cap"] = size(mat, 2)
 
     scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
 
     # Emission limits
     if setup["CO2Cap"] == 1
         #  CO2 emissions cap in mass
-        my_range = column_range("CO_2_Max_Mtons")
         # note the default inputs is in million tons
         # when scaled, the constraint unit is kton
         # when not scaled, the constraint unit is ton
-        inputs["dfMaxCO2"] = Matrix{Float64}(inputs["dfCO2Cap"][:, my_range]) * 1e6 / scale_factor
+        mat = extract_matrix_from_dataframe(df, "CO_2_Max_Mtons")
+        inputs["dfMaxCO2"] = mat * 1e6 / scale_factor
 
     elseif setup["CO2Cap"] == 2 || setup["CO2Cap"] == 3
         #  CO2 emissions rate applied per MWh
-        my_range = column_range("CO_2_Max_tons_MWh")
+        mat = extract_matrix_from_dataframe(df, "CO_2_Max_tons_MWh")
         # no scale_factor is needed since this is a ratio
-        inputs["dfMaxCO2Rate"] = Matrix{Float64}(inputs["dfCO2Cap"][:, my_range])
+        inputs["dfMaxCO2Rate"] = mat
     end
 
     println(filename * " Successfully Read!")

--- a/src/load_inputs/load_dataframe.jl
+++ b/src/load_inputs/load_dataframe.jl
@@ -61,3 +61,52 @@ end
 function load_dataframe_from_file(path)
     CSV.read(path, DataFrame, header=1)
 end
+
+@doc raw"""
+    extract_matrix_from_dataframe(df::DataFrame, columnprefix::AbstractString)
+
+Finds all columns in the dataframe which are of the form columnprefix_[Integer],
+and extracts them in order into a matrix. The function also checks that there's at least
+one column with this prefix, and that all columns numbered from 1...N exist.
+
+This is now acceptable:
+```
+ESR_1, other_thing, ESR_3, ESR_2,
+  0.1,           1,   0.3,   0.2,
+  0.4,           2,   0.6,   0.5,
+```
+"""
+function extract_matrix_from_dataframe(df::DataFrame, columnprefix::AbstractString)
+    all_columns = names(df)
+
+    # 2 is the length of the '_' connector plus one for indexing
+    get_integer_part(c) = tryparse(Int, c[length(columnprefix)+2:end])
+
+    # if prefix is "ESR", the column name should be like "ESR_1"
+    function is_of_this_column_type(c)
+        startswith(c, columnprefix) &&
+        length(c) >= length(columnprefix) + 2 &&
+        c[length(columnprefix) + 1] == '_' &&
+        !isnothing(get_integer_part(c))
+    end
+
+    columns = filter(is_of_this_column_type, all_columns)
+    columnnumbers = sort!(get_integer_part.(columns))
+
+    if length(columnnumbers) == 0
+        msg = """an input dataframe with columns $all_columns was searched for
+        numbered columns starting with $columnprefix, but nothing was found."""
+        error(msg)
+    end
+
+    # check that the sequence of column numbers is 1..N
+    if columnnumbers != collect(1:length(columnnumbers))
+        msg = """the columns $columns in an input file must be numbered in
+        a complete sequence from 1...N. It looks like some of the sequence is missing.
+        This error could also occur if there are two columns with the same number."""
+        error(msg)
+    end
+
+    sorted_columns = columnprefix .* '_' .* string.(columnnumbers)
+    Matrix(dropmissing(df[:, sorted_columns]))
+end

--- a/src/load_inputs/load_energy_share_requirement.jl
+++ b/src/load_inputs/load_energy_share_requirement.jl
@@ -23,14 +23,9 @@ Read input parameters related to mimimum energy share requirement constraints
 function load_energy_share_requirement!(setup::Dict, path::AbstractString, inputs::Dict)
     filename = "Energy_share_requirement.csv"
     df = load_dataframe(joinpath(path, filename))
-
-    f = s -> startswith(s, "ESR")
-    columns = names(df)
-    first_col = findfirst(f, columns)
-    last_col = findlast(f, columns)
-
-    inputs["dfESR"] = Matrix{Float64}(df[:, first_col:last_col])
-    inputs["nESR"] = count(f, columns)
+    mat = extract_matrix_from_dataframe(df, "ESR")
+    inputs["dfESR"] = mat
+    inputs["nESR"] = size(mat, 2)
 
     println(filename * " Successfully Read!")
 end


### PR DESCRIPTION
This allows sets of columns to be extracted from a dataframe into a matrix, for columns which are in any order. Previously the columns needed to be consecutive and in order.

For example, the ESR_1, ESR_2, ... ESR_N columns in Energy_share_requirement.csv can now be provided in any order.