### PR TITLE
Deduplicate constraints

### DIFF
--- a/src/GenX.jl
+++ b/src/GenX.jl
@@ -104,6 +104,7 @@ include("load_inputs/load_inputs.jl")
 include("time_domain_reduction/time_domain_reduction.jl")
 
 #Core GenX Features
+include("model/utility.jl")
 include("model/core/discharge/discharge.jl")
 include("model/core/discharge/investment_discharge.jl")
 

--- a/src/model/resources/flexible_demand/flexible_demand.jl
+++ b/src/model/resources/flexible_demand/flexible_demand.jl
@@ -61,12 +61,7 @@ T = inputs["T"]     # Number of time steps (hours)
 Z = inputs["Z"]     # Number of zones
 FLEX = inputs["FLEX"] # Set of flexible demand resources
 
-START_SUBPERIODS = inputs["START_SUBPERIODS"]
-INTERIOR_SUBPERIODS = inputs["INTERIOR_SUBPERIODS"]
-
 hours_per_subperiod = inputs["hours_per_subperiod"] # Total number of hours per subperiod
-
-END_HOURS = START_SUBPERIODS .+ hours_per_subperiod .- 1 # Last subperiod of each representative period
 
 ### Variables ###
 

--- a/src/model/resources/flexible_demand/flexible_demand.jl
+++ b/src/model/resources/flexible_demand/flexible_demand.jl
@@ -142,32 +142,3 @@ end
 return EP
 end
 
-@doc raw"""
-    hoursafter(p::Int, t::Int, a::Int)
-
-Determines the time index a hours after index t in
-a landscape starting from t=1 which is separated
-into distinct periods of length p.
-
-For example, if p = 10,
-1 hour after t=9 is t=10,
-1 hour after t=10 is t=1,
-1 hour after t=11 is t=2
-"""
-function hoursafter(p::Int, t::Int, a::Int)::Int
-    period = div(t - 1, p)
-    return period * p + mod1(t + a, p)
-end
-
-@doc raw"""
-    hoursafter(p::Int, t::Int, b::UnitRange)
-
-This is a generalization of hoursafter(... b::Int)
-to allow for example a=1:3 to fetch a Vector{Int} of the three hours after
-time index t.
-"""
-function hoursafter(p::Int, t::Int, a::UnitRange{Int})::Vector{Int}
-    period = div(t - 1, p)
-    return period * p .+ mod1.(t .+ a, p)
-
-end

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -146,7 +146,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 	end
 	##CO2 Polcy Module Hydro Res Generation by zone
 	@expression(EP, eGenerationByHydroRes[z=1:Z, t=1:T], # the unit is GW
-		sum(EP[:vP][y,t] for y in intersect(inputs["HYDRO_RES"], dfGen[dfGen[!,:Zone].==z,:R_ID]))
+		sum(EP[:vP][y,t] for y in intersect(HYDRO_RES, dfGen[dfGen[!,:Zone].==z,:R_ID]))
 	)
 	EP[:eGenerationByZone] += eGenerationByHydroRes
 

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -81,9 +81,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 	T = inputs["T"]     # Number of time steps (hours)
 	Z = inputs["Z"]     # Number of zones
 
-	hours_per_subperiod = inputs["hours_per_subperiod"] 	# total number of hours per subperiod
-	START_SUBPERIODS = inputs["START_SUBPERIODS"]	# set of indexes for all time periods that start a subperiod (e.g. sample day/week)
-	INTERIOR_SUBPERIODS = inputs["INTERIOR_SUBPERIODS"] # set of indexes for all time periods that do not start a
+	p = inputs["hours_per_subperiod"] 	# total number of hours per subperiod
 
 	HYDRO_RES = inputs["HYDRO_RES"]	# Set of all reservoir hydro resources, used for common constraints
 	HYDRO_RES_KNOWN_CAP = inputs["HYDRO_RES_KNOWN_CAP"] # Reservoir hydro resources modeled with unknown reservoir energy capacity
@@ -118,19 +116,14 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 		# Energy stored in reservoir at end of each other hour is equal to energy at end of prior hour less generation and spill and + inflows in the current hour
 		# The ["pP_Max"][y,t] term here refers to inflows as a fraction of peak discharge power capacity.
 		# DEV NOTE: Last inputs["pP_Max"][y,t] term above is inflows; currently part of capacity factors inputs in Generators_variability.csv but should be moved to its own Hydro_inflows.csv input in future.
-		cHydroReservoirInterior[y in HYDRO_RES, t in INTERIOR_SUBPERIODS], EP[:vS_HYDRO][y,t] == EP[:vS_HYDRO][y,t-1] - (1/dfGen[y,:Eff_Down]*EP[:vP][y,t]) - vSPILL[y,t] +inputs["pP_Max"][y,t]*EP[:eTotalCap][y]
 
-		# Constraints for reservoir hydro with time wrapping from end of sample period to start
-		cHydroReservoirWrapStart[y in HYDRO_RES, t in START_SUBPERIODS], EP[:vS_HYDRO][y,t] == (EP[:vS_HYDRO][y,t+hours_per_subperiod-1]
-				- (1/dfGen[y,:Eff_Down]*EP[:vP][y,t]) - vSPILL[y,t] +  inputs["pP_Max"][y,t]*EP[:eTotalCap][y])
+		# Constraints for reservoir hydro
+		cHydroReservoir[y in HYDRO_RES, t in 1:T], EP[:vS_HYDRO][y,t] == (EP[:vS_HYDRO][y, hoursbefore(p,t,1)]
+				- (1/dfGen[y,:Eff_Down]*EP[:vP][y,t]) - vSPILL[y,t] + inputs["pP_Max"][y,t]*EP[:eTotalCap][y])
 
-		# Maximum ramp up and down between consecutive hours
-		cRampUpInterior[y in HYDRO_RES, t in INTERIOR_SUBPERIODS], EP[:vP][y,t] - EP[:vP][y,t-1] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
-		cRampDownInterior[y in HYDRO_RES, t in INTERIOR_SUBPERIODS], EP[:vP][y,t-1] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
-
-		# Maximum ramp up and down between consecutive hours, wrapping from end of sample period to start of sample period
-		cRampUpWrapStart[y in HYDRO_RES, t in START_SUBPERIODS], EP[:vP][y,t] - EP[:vP][y,t+hours_per_subperiod-1] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
-		cRampDownWrapStart[y in HYDRO_RES, t in START_SUBPERIODS], EP[:vP][y,t+hours_per_subperiod-1] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
+		# Maximum ramp up and down
+		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] - EP[:vP][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
+		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
 
 		# Minimum streamflow running requirements (power generation and spills must be >= min value) in all hours
 		cHydroMinFlow[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] + EP[:vSPILL][y,t] >= dfGen[y,:Min_Power]*EP[:eTotalCap][y]
@@ -140,10 +133,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 		# DEV NOTE: We do not currently account for hydro power plant outages - leave it for later to figure out if we should.
 		# DEV NOTE (CONTD): If we defin pPMax as hourly availability of the plant and define inflows as a separate parameter, then notation will be consistent with its use for other resources
 		cHydroMaxPower[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] <= EP[:eTotalCap][y]
-		cHydroMaxOutflowInterior[y in HYDRO_RES, t in INTERIOR_SUBPERIODS], EP[:vP][y,t] <= EP[:vS_HYDRO][y,t-1]
-
-		# Maximum discharging rate must be less than available stored energy at start of hour, whichever is less, wrapping from end of sample period to start of sample period
-		cHydroMaxOutflowStart[y in HYDRO_RES, t in START_SUBPERIODS], EP[:vP][y,t] <= EP[:vS_HYDRO][y,t+hours_per_subperiod-1]
+		cHydroMaxOutflow[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] <= EP[:vS_HYDRO][y, hoursbefore(p,t,1)]
 	end)
 
 	### Constraints to limit maximum energy in storage based on known limits on reservoir energy capacity (only for HYDRO_RES_KNOWN_CAP)

--- a/src/model/resources/storage/storage_all.jl
+++ b/src/model/resources/storage/storage_all.jl
@@ -76,17 +76,14 @@ function storage_all!(EP::Model, inputs::Dict, setup::Dict)
 
 	# Links state of charge in first time step with decisions in last time step of each subperiod
 	# We use a modified formulation of this constraint (cSoCBalLongDurationStorageStart) when operations wrapping and long duration storage are being modeled
-	
 	if OperationWrapping ==1 && !isempty(inputs["STOR_LONG_DURATION"])
-		@constraint(EP, cSoCBalStart[t in START_SUBPERIODS, y in STOR_SHORT_DURATION], EP[:vS][y,t] ==
-			EP[:vS][y,t+hours_per_subperiod-1]-(1/dfGen[y,:Eff_Down]*EP[:vP][y,t])
-			+(dfGen[y,:Eff_Up]*EP[:vCHARGE][y,t])-(dfGen[y,:Self_Disch]*EP[:vS][y,t+hours_per_subperiod-1]))
+		CONSTRAINTSET = STOR_SHORT_DURATION
 	else
-		@constraint(EP, cSoCBalStart[t in START_SUBPERIODS, y in STOR_ALL], EP[:vS][y,t] ==
-			EP[:vS][y,t+hours_per_subperiod-1]-(1/dfGen[y,:Eff_Down]*EP[:vP][y,t])
-			+(dfGen[y,:Eff_Up]*EP[:vCHARGE][y,t])-(dfGen[y,:Self_Disch]*EP[:vS][y,t+hours_per_subperiod-1]))
+		CONSTRAINTSET = STOR_ALL
 	end
-	
+	@constraint(EP, cSoCBalStart[t in START_SUBPERIODS, y in CONSTRAINTSET], EP[:vS][y,t] ==
+		EP[:vS][y,t+hours_per_subperiod-1] - (1/dfGen[y,:Eff_Down] * EP[:vP][y,t])
+		+ (dfGen[y,:Eff_Up]*EP[:vCHARGE][y,t]) - (dfGen[y,:Self_Disch] * EP[:vS][y,t+hours_per_subperiod-1]))
 
 	@constraints(EP, begin
 
@@ -118,7 +115,7 @@ function storage_all!(EP::Model, inputs::Dict, setup::Dict)
 	end
 	#From co2 Policy module
 	@expression(EP, eELOSSByZone[z=1:Z],
-		sum(EP[:eELOSS][y] for y in intersect(inputs["STOR_ALL"], dfGen[dfGen[!,:Zone].==z,:R_ID]))
+		sum(EP[:eELOSS][y] for y in intersect(STOR_ALL, dfGen[dfGen[!,:Zone].==z,:R_ID]))
 	)
 end
 

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -357,31 +357,3 @@ function thermal_commit_reserves!(EP::Model, inputs::Dict)
 
 end
 
-@doc raw"""
-    hoursbefore(p::Int, t::Int, b::Int)
-
-Determines the time index b hours before index t in
-a landscape starting from t=1 which is separated
-into distinct periods of length p.
-
-For example, if p = 10,
-1 hour before t=1 is t=10,
-1 hour before t=10 is t=9
-1 hour before t=11 is t=20
-"""
-function hoursbefore(p::Int, t::Int, b::Int)::Int
-	period = div(t - 1, p)
-	return period * p + mod1(t - b, p)
-end
-
-@doc raw"""
-    hoursbefore(p::Int, t::Int, b::UnitRange)
-
-This is a generalization of hoursbefore(... b::Int)
-to allow for example b=1:3 to fetch a Vector{Int} of the three hours before
-time index t.
-"""
-function hoursbefore(p::Int, t::Int, b::UnitRange{Int})::Vector{Int}
-	period = div(t - 1, p)
-	return period * p .+ mod1.(t .- b, p)
-end

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -150,11 +150,9 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 	Z = inputs["Z"]     # Number of zones
 	G = inputs["G"]     # Number of resources
 
-	hours_per_subperiod = inputs["hours_per_subperiod"] #total number of hours per subperiod
+	p = inputs["hours_per_subperiod"] #total number of hours per subperiod
 
 	THERM_COMMIT = inputs["THERM_COMMIT"]
-	START_SUBPERIODS = inputs["START_SUBPERIODS"]
-	INTERIOR_SUBPERIODS = inputs["INTERIOR_SUBPERIODS"]
 
 	### Expressions ###
 
@@ -175,10 +173,7 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 
 	# Commitment state constraint linking startup and shutdown decisions (Constraint #4)
 	@constraints(EP, begin
-		# For Start Hours, links first time step with last time step in subperiod
-		[y in THERM_COMMIT, t in START_SUBPERIODS], EP[:vCOMMIT][y,t] == EP[:vCOMMIT][y,(t+hours_per_subperiod-1)] + EP[:vSTART][y,t] - EP[:vSHUT][y,t]
-		# For all other hours, links commitment state in hour t with commitment state in prior hour + sum of start up and shut down in current hour
-		[y in THERM_COMMIT, t in INTERIOR_SUBPERIODS], EP[:vCOMMIT][y,t] == EP[:vCOMMIT][y,t-1] + EP[:vSTART][y,t] - EP[:vSHUT][y,t]
+		[y in THERM_COMMIT, t in 1:T], EP[:vCOMMIT][y,t] == EP[:vCOMMIT][y, hoursbefore(p, t, 1)] + EP[:vSTART][y,t] - EP[:vSHUT][y,t]
 	end)
 
 	### Maximum ramp up and down between consecutive hours (Constraints #5-6)
@@ -186,29 +181,16 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 	## For Start Hours
 	# Links last time step with first time step, ensuring position in hour 1 is within eligible ramp of final hour position
 		# rampup constraints
-	@constraint(EP,[y in THERM_COMMIT, t in START_SUBPERIODS],
-		EP[:vP][y,t]-EP[:vP][y,(t+hours_per_subperiod-1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
+		EP[:vP][y,t]-EP[:vP][y, hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Up_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
 
 		# rampdown constraints
-	@constraint(EP,[y in THERM_COMMIT, t in START_SUBPERIODS],
-		EP[:vP][y,(t+hours_per_subperiod-1)]-EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
+		EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
-
-	## For Interior Hours
-		# rampup constraints
-	@constraint(EP,[y in THERM_COMMIT, t in INTERIOR_SUBPERIODS],
-		EP[:vP][y,t]-EP[:vP][y,t-1] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
-			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Up_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
-			-dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
-
-		# rampdown constraints
-	@constraint(EP,[y in THERM_COMMIT, t in INTERIOR_SUBPERIODS],
-		EP[:vP][y,t-1]-EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
-			-dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
-			+min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
 
 	### Minimum and maximum power output constraints (Constraints #7-8)
 	if setup["Reserves"] == 1
@@ -225,7 +207,6 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 	end
 
 	### Minimum up and down times (Constraints #9-10)
-	p = hours_per_subperiod
 	Up_Time = zeros(Int, nrow(dfGen))
 	Up_Time[THERM_COMMIT] .= Int.(floor.(dfGen[THERM_COMMIT,:Up_Time]))
 	@constraint(EP, [y in THERM_COMMIT, t in 1:T],

--- a/src/model/resources/thermal/thermal_no_commit.jl
+++ b/src/model/resources/thermal/thermal_no_commit.jl
@@ -66,10 +66,7 @@ function thermal_no_commit!(EP::Model, inputs::Dict, setup::Dict)
 	T = inputs["T"]     # Number of time steps (hours)
 	Z = inputs["Z"]     # Number of zones
 
-	hours_per_subperiod = inputs["hours_per_subperiod"] #total number of hours per subperiod
-
-	START_SUBPERIODS = inputs["START_SUBPERIODS"]
-	INTERIOR_SUBPERIODS = inputs["INTERIOR_SUBPERIODS"]
+	p = inputs["hours_per_subperiod"] #total number of hours per subperiod
 
 	THERM_NO_COMMIT = inputs["THERM_NO_COMMIT"]
 
@@ -87,19 +84,10 @@ function thermal_no_commit!(EP::Model, inputs::Dict, setup::Dict)
 	@constraints(EP, begin
 
 		## Maximum ramp up between consecutive hours
-		# Start Hours: Links last time step with first time step, ensuring position in hour 1 is within eligible ramp of final hour position
-		# NOTE: We should make wrap-around a configurable option
-		[y in THERM_NO_COMMIT, t in START_SUBPERIODS], EP[:vP][y,t]-EP[:vP][y,(t+hours_per_subperiod-1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
-
-		# Interior Hours
-		[y in THERM_NO_COMMIT, t in INTERIOR_SUBPERIODS], EP[:vP][y,t]-EP[:vP][y,t-1] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
+        [y in THERM_NO_COMMIT, t in 1:T], EP[:vP][y,t] - EP[:vP][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
 
 		## Maximum ramp down between consecutive hours
-		# Start Hours: Links last time step with first time step, ensuring position in hour 1 is within eligible ramp of final hour position
-		[y in THERM_NO_COMMIT, t in START_SUBPERIODS], EP[:vP][y,(t+hours_per_subperiod-1)] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
-
-		# Interior Hours
-		[y in THERM_NO_COMMIT, t in INTERIOR_SUBPERIODS], EP[:vP][y,t-1] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
+		[y in THERM_NO_COMMIT, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
 	end)
 
 	### Minimum and maximum power output constraints (Constraints #3-4)

--- a/src/model/utility.jl
+++ b/src/model/utility.jl
@@ -1,0 +1,75 @@
+"""
+GenX: An Configurable Capacity Expansion Model
+Copyright (C) 2021,  Massachusetts Institute of Technology
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+A complete copy of the GNU General Public License v2 (GPLv2) is available
+in LICENSE.txt.  Users uncompressing this from an archive may not have
+received this license file.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+@doc raw"""
+    hoursbefore(p::Int, t::Int, b::Int)
+
+Determines the time index b hours before index t in
+a landscape starting from t=1 which is separated
+into distinct periods of length p.
+
+For example, if p = 10,
+1 hour before t=1 is t=10,
+1 hour before t=10 is t=9
+1 hour before t=11 is t=20
+"""
+function hoursbefore(p::Int, t::Int, b::Int)::Int
+	period = div(t - 1, p)
+	return period * p + mod1(t - b, p)
+end
+
+@doc raw"""
+    hoursbefore(p::Int, t::Int, b::UnitRange)
+
+This is a generalization of hoursbefore(... b::Int)
+to allow for example b=1:3 to fetch a Vector{Int} of the three hours before
+time index t.
+"""
+function hoursbefore(p::Int, t::Int, b::UnitRange{Int})::Vector{Int}
+	period = div(t - 1, p)
+	return period * p .+ mod1.(t .- b, p)
+end
+
+
+@doc raw"""
+    hoursafter(p::Int, t::Int, a::Int)
+
+Determines the time index a hours after index t in
+a landscape starting from t=1 which is separated
+into distinct periods of length p.
+
+For example, if p = 10,
+1 hour after t=9 is t=10,
+1 hour after t=10 is t=1,
+1 hour after t=11 is t=2
+"""
+function hoursafter(p::Int, t::Int, a::Int)::Int
+    period = div(t - 1, p)
+    return period * p + mod1(t + a, p)
+end
+
+@doc raw"""
+    hoursafter(p::Int, t::Int, b::UnitRange)
+
+This is a generalization of hoursafter(... b::Int)
+to allow for example a=1:3 to fetch a Vector{Int} of the three hours after
+time index t.
+"""
+function hoursafter(p::Int, t::Int, a::UnitRange{Int})::Vector{Int}
+    period = div(t - 1, p)
+    return period * p .+ mod1.(t .+ a, p)
+
+end


### PR DESCRIPTION
These commits clean up several pairs of constraints, unifying them by using `hoursbefore`, which has been moved to a new `utility.jl` file for general utility functions.

Although resulting formulation should be mathematically identical (and I'd appreciate a reviewer to verify this!) in practice, since the constraints are now in a different order, solvers will find a slightly different solution.