### PR TITLE
Correct scaling for CO2 Emissions

### DIFF
--- a/src/write_outputs/write_emissions.jl
+++ b/src/write_outputs/write_emissions.jl
@@ -58,14 +58,14 @@ function write_emissions(path::AbstractString, inputs::Dict, setup::Dict, EP::Mo
 			if setup["ParameterScale"]==1
 				dfEmissions[i,:AnnualSum] = sum(inputs["omega"].*value.(EP[:eEmissionsByZone][i,:]))*ModelScalingFactor
 			else
-				dfEmissions[i,:AnnualSum] = sum(inputs["omega"].*value.(EP[:eEmissionsByZone][i,:]))/ModelScalingFactor
+				dfEmissions[i,:AnnualSum] = sum(inputs["omega"].*value.(EP[:eEmissionsByZone][i,:]))
 			end
 		end
 
 		if setup["ParameterScale"]==1
 			dfEmissions = hcat(dfEmissions, DataFrame(value.(EP[:eEmissionsByZone])*ModelScalingFactor, :auto))
 		else
-			dfEmissions = hcat(dfEmissions, DataFrame(value.(EP[:eEmissionsByZone])/ModelScalingFactor, :auto))
+			dfEmissions = hcat(dfEmissions, DataFrame(value.(EP[:eEmissionsByZone]), :auto))
 		end
 
 
@@ -98,13 +98,13 @@ function write_emissions(path::AbstractString, inputs::Dict, setup::Dict, EP::Mo
 			if setup["ParameterScale"]==1
 				dfEmissions[!,:AnnualSum][i] = sum(inputs["omega"].*value.(EP[:eEmissionsByZone][i,:])) *ModelScalingFactor
 			else
-				dfEmissions[!,:AnnualSum][i] = sum(inputs["omega"].*value.(EP[:eEmissionsByZone][i,:]))/ModelScalingFactor
+				dfEmissions[!,:AnnualSum][i] = sum(inputs["omega"].*value.(EP[:eEmissionsByZone][i,:]))
 			end
 		end
 		if setup["ParameterScale"]==1
 			dfEmissions = hcat(dfEmissions, DataFrame(value.(EP[:eEmissionsByZone])*ModelScalingFactor, :auto))
 		else
-			dfEmissions = hcat(dfEmissions, DataFrame(value.(EP[:eEmissionsByZone])/ModelScalingFactor, :auto))
+			dfEmissions = hcat(dfEmissions, DataFrame(value.(EP[:eEmissionsByZone]), :auto))
 		end
 		auxNew_Names=[Symbol("Zone");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 		rename!(dfEmissions,auxNew_Names)


### PR DESCRIPTION
Removes division by ModelScalingFacroe when ParameterScale is set to 0, to express the COR emissions in tons (instead of kilotons).