### PR TITLE
CO2 Cap Condition check

### DIFF
--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -190,7 +190,9 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 
 	# Policies
 	# CO2 emissions limits
-	co2_cap!(EP, inputs, setup)
+	if setup["CO2Cap"] >= 1
+ 		co2_cap!(EP, inputs, setup)
+ 	end
 
 	# Endogenous Retirements
 	if setup["MultiStage"] > 0


### PR DESCRIPTION
This PR modifies the generate_model.jl file by changing the following line of code:

co2_cap!(EP, inputs, setup)

to

if setup["CO2Cap"] >= 1
		co2_cap!(EP, inputs, setup)
end
This is essential because if CO2 capacity constraints are not taken into consideration, then we don't need to execute the co2_cap!(EP, inputs, setup) function.