### PR TITLE
Inclusion of Reserve and Regulation in ramp limits

### DIFF
--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -32,13 +32,13 @@ Note: in future updates, an option to model hydro resources with large reservoir
 The following constraints enforce hourly changes in power output (ramps down and ramps up) to be less than the maximum ramp rates ($\kappa^{down}_{y,z}$ and $\kappa^{up}_{y,z}$ ) in per unit terms times the total installed capacity of technology y ($\Delta^{total}_{y,z}$).
 ```math
 \begin{aligned}
-&\Theta_{y,z,t} - \Theta_{y,z,t-1} \leq \kappa^{up}_{y,z} \times \Delta^{total}_{y,z}
+&\Theta_{y,z,t} + f_{y,z,t} + r_{y,z,t} - \Theta_{y,z,t-1} - f_{y,z,t-1} \leq \kappa^{up}_{y,z} \times \Delta^{total}_{y,z}
 \hspace{2 cm}  \forall y \in \mathcal{W}, z \in \mathcal{Z}, t \in \mathcal{T}
 \end{aligned}
 ```
 ```math
 \begin{aligned}
-&\Theta_{y,z,t-1} - \Theta_{y,z,t} \leq \kappa^{down}_{y,z} \Delta^{total}_{y,z}
+&\Theta_{y,z,t-1} + f_{y,z,t-1} - \Theta_{y,z,t} - f_{y,z,t} - r_{y,z,t} \leq \kappa^{down}_{y,z} \Delta^{total}_{y,z}
 \hspace{2 cm}  \forall y \in \mathcal{W}, z \in \mathcal{Z}, t \in \mathcal{T}
 \end{aligned}
 ```

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -38,7 +38,7 @@ The following constraints enforce hourly changes in power output (ramps down and
 ```
 ```math
 \begin{aligned}
-&\Theta_{y,z,t-1} + f_{y,z,t-1} - \Theta_{y,z,t} - f_{y,z,t} - r_{y,z,t} \leq \kappa^{down}_{y,z} \Delta^{total}_{y,z}
+&\Theta_{y,z,t-1} + f_{y,z,t-1}  + r_{y,z,t-1} - \Theta_{y,z,t} - f_{y,z,t}\leq \kappa^{down}_{y,z} \Delta^{total}_{y,z}
 \hspace{2 cm}  \forall y \in \mathcal{W}, z \in \mathcal{Z}, t \in \mathcal{T}
 \end{aligned}
 ```
@@ -133,7 +133,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 
 		# Maximum ramp up and down
 		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]+ EP[:vREG][y,t]+EP[:vRSV][y,t] - EP[:vP][y, hoursbefore(p,t,1)]-EP[:vREG][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
-		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)] - EP[:vP][y,t] - EP[:vREG][y,t] - EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
+		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)] + EP[:vRSV][y, hoursbefore(p,t,1)] - EP[:vP][y,t] - EP[:vREG][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
 		# Minimum streamflow running requirements (power generation and spills must be >= min value) in all hours
 		cHydroMinFlow[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] + EP[:vSPILL][y,t] >= dfGen[y,:Min_Power]*EP[:eTotalCap][y]
 		# DEV NOTE: When creating new hydro inputs, should rename Min_Power with Min_flow or similar for clarity since this includes spilled water as well

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -132,7 +132,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 				- (1/dfGen[y,:Eff_Down]*EP[:vP][y,t]) - vSPILL[y,t] + inputs["pP_Max"][y,t]*EP[:eTotalCap][y])
 
 		# Maximum ramp up and down
-		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]+ EP[:vREG][y,t]+EP[:vRSV][y,t]- EP[:vP][y, hoursbefore(p,t,1)]-EP[:vREG][y, hoursbefore(p,t,1)]-EP[:vRSV][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
+		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]+ EP[:vREG][y,t]+EP[:vRSV][y,t] - EP[:vP][y, hoursbefore(p,t,1)]-EP[:vREG][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
 		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)]+EP[:vRSV][y, hoursbefore(p,t,1)] - EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
 
 		# Minimum streamflow running requirements (power generation and spills must be >= min value) in all hours

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -132,8 +132,8 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 				- (1/dfGen[y,:Eff_Down]*EP[:vP][y,t]) - vSPILL[y,t] + inputs["pP_Max"][y,t]*EP[:eTotalCap][y])
 
 		# Maximum ramp up and down
-		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] - EP[:vP][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
-		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
+		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]+ EP[:vREG][y,t]+EP[:vRSV][y,t]- EP[:vP][y, hoursbefore(p,t,1)]-EP[:vREG][y, hoursbefore(p,t,1)]-EP[:vRSV][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
+		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)]+EP[:vRSV][y, hoursbefore(p,t,1)] - EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
 
 		# Minimum streamflow running requirements (power generation and spills must be >= min value) in all hours
 		cHydroMinFlow[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] + EP[:vSPILL][y,t] >= dfGen[y,:Min_Power]*EP[:eTotalCap][y]

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -133,8 +133,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 
 		# Maximum ramp up and down
 		cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]+ EP[:vREG][y,t]+EP[:vRSV][y,t] - EP[:vP][y, hoursbefore(p,t,1)]-EP[:vREG][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]
-		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)]+EP[:vRSV][y, hoursbefore(p,t,1)] - EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
-
+		cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)] - EP[:vP][y,t] - EP[:vREG][y,t] - EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]
 		# Minimum streamflow running requirements (power generation and spills must be >= min value) in all hours
 		cHydroMinFlow[y in HYDRO_RES, t in 1:T], EP[:vP][y,t] + EP[:vSPILL][y,t] >= dfGen[y,:Min_Power]*EP[:eTotalCap][y]
 		# DEV NOTE: When creating new hydro inputs, should rename Min_Power with Min_flow or similar for clarity since this includes spilled water as well

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -180,13 +180,13 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 
 	## For Start Hours
 	# Links last time step with first time step, ensuring position in hour 1 is within eligible ramp of final hour position
-		# rampup constraints
+	# rampup constraints
 	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
-		EP[:vP][y,t]+EP[:vREG][y,t]+EP[:vRSV][y,t]-EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vREG][y,hoursbefore(p, t, 1)]-EP[:vRSV][y,hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+		EP[:vP][y,t]+EP[:vREG][y,t]+EP[:vRSV][y,t]-EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vREG][y,hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Up_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
 
-		# rampdown constraints
+	# rampdown constraints
 	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
 		EP[:vP][y, hoursbefore(p, t, 1)]+EP[:vREG][y,hoursbefore(p, t, 1)]+EP[:vRSV][y,hoursbefore(p, t, 1)]-EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -182,15 +182,16 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 	# Links last time step with first time step, ensuring position in hour 1 is within eligible ramp of final hour position
 		# rampup constraints
 	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
-		EP[:vP][y,t]-EP[:vP][y, hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+		EP[:vP][y,t]+EP[:vREG][y,t]+EP[:vRSV][y,t]-EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vREG][y,hoursbefore(p, t, 1)]-EP[:vRSV][y,hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Up_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
 
 		# rampdown constraints
 	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
-		EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+		EP[:vP][y, hoursbefore(p, t, 1)]+EP[:vREG][y,hoursbefore(p, t, 1)]+EP[:vRSV][y,hoursbefore(p, t, 1)]-EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
+
 
 	### Minimum and maximum power output constraints (Constraints #7-8)
 	if setup["Reserves"] == 1

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -77,7 +77,7 @@ Thermal resources subject to unit commitment ($y \in UC$) adhere to the followin
 
 ```math
 \begin{aligned}
-	\Theta_{y,z,t-1} + f_{y, z, t-1}- \Theta_{y,z,t}-f_{y, z, t}-r_{y, z, t} &\leq  \kappa^{down}_{y,z} \cdot \Omega^{size}_{y,z} \cdot (\nu_{y,z,t} - \chi_{y,z,t}) & \\[6pt]
+	\Theta_{y,z,t-1} + f_{y, z, t-1}+r_{y, z, t-1} - \Theta_{y,z,t}-f_{y, z, t}&\leq  \kappa^{down}_{y,z} \cdot \Omega^{size}_{y,z} \cdot (\nu_{y,z,t} - \chi_{y,z,t}) & \\[6pt]
 	\qquad & - \: \rho^{min}_{y,z} \cdot \Omega^{size}_{y,z} \cdot \chi_{y,z,t} & \hspace{0.5cm} \forall y \in \mathcal{UC}, \forall z \in \mathcal{Z}, \forall t \in \mathcal{T}  \\[6pt]
 	\qquad & + \: \text{min}( \rho^{max}_{y,z,t}, \text{max}( \rho^{min}_{y,z}, \kappa^{down}_{y,z} ) ) \cdot \Omega^{size}_{y,z} \cdot \zeta_{y,z,t} &
 \end{aligned}
@@ -187,10 +187,12 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
 
 	# rampdown constraints
-	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
-		EP[:vP][y, hoursbefore(p, t, 1)]+EP[:vREG][y,hoursbefore(p, t, 1)]-EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+	@constraint(EP,[y in THERM_COMMIT, t in 1:T], 
+		EP[:vP][y, hoursbefore(p,t,1)] + EP[:vREG][y, hoursbefore(p,t,1)] + EP[:vRSV][y, hoursbefore(p,t,1)] - EP[:vP][y,t] - EP[:vREG][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
+
+
 
 
 	### Minimum and maximum power output constraints (Constraints #7-8)

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -188,7 +188,7 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
 
 	# rampdown constraints
 	@constraint(EP,[y in THERM_COMMIT, t in 1:T],
-		EP[:vP][y, hoursbefore(p, t, 1)]+EP[:vREG][y,hoursbefore(p, t, 1)]+EP[:vRSV][y,hoursbefore(p, t, 1)]-EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
+		EP[:vP][y, hoursbefore(p, t, 1)]+EP[:vREG][y,hoursbefore(p, t, 1)]-EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
 			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
 			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])
 

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -77,7 +77,7 @@ Thermal resources subject to unit commitment ($y \in UC$) adhere to the followin
 
 ```math
 \begin{aligned}
-	\Theta_{y,z,t-1} - \Theta_{y,z,t} &\leq  \kappa^{down}_{y,z} \cdot \Omega^{size}_{y,z} \cdot (\nu_{y,z,t} - \chi_{y,z,t}) & \\[6pt]
+	\Theta_{y,z,t-1} + f_{y, z, t-1}- \Theta_{y,z,t}-f_{y, z, t}-r_{y, z, t} &\leq  \kappa^{down}_{y,z} \cdot \Omega^{size}_{y,z} \cdot (\nu_{y,z,t} - \chi_{y,z,t}) & \\[6pt]
 	\qquad & - \: \rho^{min}_{y,z} \cdot \Omega^{size}_{y,z} \cdot \chi_{y,z,t} & \hspace{0.5cm} \forall y \in \mathcal{UC}, \forall z \in \mathcal{Z}, \forall t \in \mathcal{T}  \\[6pt]
 	\qquad & + \: \text{min}( \rho^{max}_{y,z,t}, \text{max}( \rho^{min}_{y,z}, \kappa^{down}_{y,z} ) ) \cdot \Omega^{size}_{y,z} \cdot \zeta_{y,z,t} &
 \end{aligned}
@@ -85,14 +85,14 @@ Thermal resources subject to unit commitment ($y \in UC$) adhere to the followin
 
 ```math
 \begin{aligned}
-	\Theta_{y,z,t} - \Theta_{y,z,t-1} &\leq  \kappa^{up}_{y,z} \cdot \Omega^{size}_{y,z} \cdot (\nu_{y,z,t} - \chi_{y,z,t}) & \\[6pt]
+	\Theta_{y,z,t}+f_{y, z, t}+r_{y, z, t} - \Theta_{y,z,t-1}- f_{y, z, t-1} &\leq  \kappa^{up}_{y,z} \cdot \Omega^{size}_{y,z} \cdot (\nu_{y,z,t} - \chi_{y,z,t}) & \\[6pt]
 	\qquad & + \: \text{min}( \rho^{max}_{y,z,t}, \text{max}( \rho^{min}_{y,z}, \kappa^{up}_{y,z} ) ) \cdot \Omega^{size}_{y,z} \cdot \chi_{y,z,t} & \hspace{0.5cm} \forall y \in \mathcal{UC}, \forall z \in \mathcal{Z}, \forall t \in \mathcal{T} \\[6pt]
 	\qquad & - \: \rho^{min}_{y,z} \cdot \Omega^{size}_{y,z} \cdot \zeta_{y,z,t} &
 \end{aligned}
 ```
 (See Constraints 5-6 in the code)
 
-where decision $\Theta_{y,z,t}$ is the energy injected into the grid by technology $y$ in zone $z$ at time $t$, parameter $\kappa_{y,z,t}^{up|down}$ is the maximum ramp-up or ramp-down rate as a percentage of installed capacity, parameter $\rho_{y,z}^{min}$ is the minimum stable power output per unit of installed capacity, and parameter $\rho_{y,z,t}^{max}$ is the maximum available generation per unit of installed capacity. These constraints account for the ramping limits for committed (online) units as well as faster changes in power enabled by units starting or shutting down in the current time step.
+where decision $\Theta_{y,z,t}$, $f_{y, z, t}$, and $r_{y, z, t}$ are respectively, the energy injected into the grid, regulation, and reserve by technology $y$ in zone $z$ at time $t$, parameter $\kappa_{y,z,t}^{up|down}$ is the maximum ramp-up or ramp-down rate as a percentage of installed capacity, parameter $\rho_{y,z}^{min}$ is the minimum stable power output per unit of installed capacity, and parameter $\rho_{y,z,t}^{max}$ is the maximum available generation per unit of installed capacity. These constraints account for the ramping limits for committed (online) units as well as faster changes in power enabled by units starting or shutting down in the current time step.
 
 **Minimum and maximum power output**
 


### PR DESCRIPTION
This PR attempts to correct the ramping constraints for thermal and hydro generators by introducing the reserve and regulation terms in the respective constraints and by changing 



#rampup constraint
@constraint(EP,[y in THERM_COMMIT, t in 1:T],
		EP[:vP][y,t]-EP[:vP][y, hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Up_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])

# rampdown constraints
@constraint(EP,[y in THERM_COMMIT, t in 1:T],
		EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])


To :


#rampup constraint
@constraint(EP,[y in THERM_COMMIT, t in 1:T],
		EP[:vP][y,t]+EP[:vREG][y,t]+EP[:vRSV][y,t]-EP[:vP][y, hoursbefore(p, t, 1)]-EP[:vREG][y,hoursbefore(p, t, 1)]-EP[:vRSV][y,hoursbefore(p, t, 1)] <= dfGen[y,:Ramp_Up_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Up_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])

# rampdown constraints
@constraint(EP,[y in THERM_COMMIT, t in 1:T],
		EP[:vP][y, hoursbefore(p, t, 1)]+EP[:vREG][y,hoursbefore(p, t, 1)]+EP[:vRSV][y,hoursbefore(p, t, 1)]-EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*dfGen[y,:Cap_Size]*(EP[:vCOMMIT][y,t]-EP[:vSTART][y,t])
			- dfGen[y,:Min_Power]*dfGen[y,:Cap_Size]*EP[:vSTART][y,t]
			+ min(inputs["pP_Max"][y,t],max(dfGen[y,:Min_Power],dfGen[y,:Ramp_Dn_Percentage]))*dfGen[y,:Cap_Size]*EP[:vSHUT][y,t])



for the THERMAL and for the HYDRO_RES, changes the following:



cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]- EP[:vP][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]

cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)] - EP[:vP][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]


To:


cRampUp[y in HYDRO_RES, t in 1:T], EP[:vP][y,t]+ EP[:vREG][y,t]+EP[:vRSV][y,t]- EP[:vP][y, hoursbefore(p,t,1)]-EP[:vREG][y, hoursbefore(p,t,1)]-EP[:vRSV][y, hoursbefore(p,t,1)] <= dfGen[y,:Ramp_Up_Percentage]*EP[:eTotalCap][y]

cRampDown[y in HYDRO_RES, t in 1:T], EP[:vP][y, hoursbefore(p,t,1)]+EP[:vREG][y, hoursbefore(p,t,1)]+EP[:vRSV][y, hoursbefore(p,t,1)] - EP[:vP][y,t]-EP[:vREG][y,t]-EP[:vRSV][y,t] <= dfGen[y,:Ramp_Dn_Percentage]*EP[:eTotalCap][y]


Respectively.