### PR TITLE
BarObjRng is for CPLEX, not gurobi

### DIFF
--- a/Example_Systems/MethodofMorrisExample/OneZone/Settings/gurobi_settings.yml
+++ b/Example_Systems/MethodofMorrisExample/OneZone/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: -1                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/RealSystemExample/ISONE_Singlezone/Settings/gurobi_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Singlezone/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 1                # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/RealSystemExample/ISONE_Trizone/Settings/gurobi_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-06           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 0               # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Settings/gurobi_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-06          # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 0               # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Settings/gurobi_settings.yml
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 0.001                  # Relative (p.u. of optimal) mixed integer optima
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 0               # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Settings/gurobi_settings.yml
+++ b/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-06           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 0                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/RetrofitExample/RetrofitExample_MultiStage/Settings/gurobi_settings.yml
+++ b/Example_Systems/RetrofitExample/RetrofitExample_MultiStage/Settings/gurobi_settings.yml
@@ -11,7 +11,6 @@ MIPGap: 1e-4                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: -1                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.
 OutputFlag: 0                 # Controls Gurobi output.s

--- a/Example_Systems/SmallNewEngland/OneZone/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 0                # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/SmallNewEngland/OneZone_3VREBin/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone_3VREBin/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: -1                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/SmallNewEngland/OneZone_MultiStage/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone_MultiStage/Settings/gurobi_settings.yml
@@ -11,7 +11,6 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: -1                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.
 OutputFlag: 0                 # Controls Gurobi output.s

--- a/Example_Systems/SmallNewEngland/Simple_Test_Case/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/Simple_Test_Case/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 1                # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/SmallNewEngland/Simple_Test_Case_Modified/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/Simple_Test_Case_Modified/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 1                # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/SmallNewEngland/Test_Up_Time/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/Test_Up_Time/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 1                # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/SmallNewEngland/ThreeZones/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: -1                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Settings/gurobi_settings.yml
@@ -11,7 +11,6 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: -1                 # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.
 OutputFlag: 0                 # Controls Gurobi output.s

--- a/Example_Systems/SmallNewEngland/test_Down_Time/Settings/gurobi_settings.yml
+++ b/Example_Systems/SmallNewEngland/test_Down_Time/Settings/gurobi_settings.yml
@@ -11,6 +11,5 @@ MIPGap: 1e-3                  # Relative (p.u. of optimal) mixed integer optimal
 BarConvTol: 1.0e-08           # Barrier convergence tolerance (determines when barrier terminates).
 NumericFocus: 0               # Numerical precision emphasis.
 Crossover: 1                # Barrier crossver strategy.
-BarObjRng: 1e+75              # Sets the maximum absolute value of the objective function
 PreDual: 0                    # Decides whether presolve should pass the primal or dual linear programming problem to the LP optimization algorithm.
 AggFill: 10                   # Allowed fill during presolve aggregation.


### PR DESCRIPTION
Having this setting in gurobi_settings.yml passes it to the solver. This leads to an error in Gurobi.
This commit removes this settings from the gurobi_settings.yml files.