### PR TITLE
Move constraints pertaining to investment

### DIFF
--- a/src/model/resources/storage/investment_energy.jl
+++ b/src/model/resources/storage/investment_energy.jl
@@ -146,4 +146,8 @@ function investment_energy!(EP::Model, inputs::Dict, setup::Dict)
 	# DEV NOTE: This constraint may be violated in some cases where Existing_Cap_MWh is <= Min_Cap_MWh and lead to infeasabilty
 	@constraint(EP, cMinCapEnergy[y in intersect(dfGen[dfGen.Min_Cap_MWh.>0,:R_ID], STOR_ALL)], eTotalCapEnergy[y] >= dfGen[y,:Min_Cap_MWh])
 
+	# Max and min constraints on energy storage capacity built (as proportion to discharge power capacity)
+	@constraint(EP, cMinCapEnergyDuration[y in STOR_ALL], EP[:eTotalCapEnergy][y] >= dfGen[y,:Min_Duration] * EP[:eTotalCap][y])
+	@constraint(EP, cMaxCapEnergyDuration[y in STOR_ALL], EP[:eTotalCapEnergy][y] <= dfGen[y,:Max_Duration] * EP[:eTotalCap][y])
+
 end

--- a/src/model/resources/storage/storage_all.jl
+++ b/src/model/resources/storage/storage_all.jl
@@ -87,10 +87,6 @@ function storage_all!(EP::Model, inputs::Dict, setup::Dict)
 
 	@constraints(EP, begin
 
-		# Max and min constraints on energy storage capacity built (as proportion to discharge power capacity)
-		[y in STOR_ALL], EP[:eTotalCapEnergy][y] >= dfGen[y,:Min_Duration] * EP[:eTotalCap][y]
-		[y in STOR_ALL], EP[:eTotalCapEnergy][y] <= dfGen[y,:Max_Duration] * EP[:eTotalCap][y]
-
 		# Maximum energy stored must be less than energy capacity
 		[y in STOR_ALL, t in 1:T], EP[:vS][y,t] <= EP[:eTotalCapEnergy][y]
 


### PR DESCRIPTION
Removed the constraints

# Max and min constraints on energy storage capacity built (as proportion to discharge power capacity)
		[y in STOR_ALL], EP[:eTotalCapEnergy][y] >= dfGen[y,:Min_Duration] * EP[:eTotalCap][y]
		[y in STOR_ALL], EP[:eTotalCapEnergy][y] <= dfGen[y,:Max_Duration] * EP[:eTotalCap][y]

from storage_all.jl to investment_energy.jl