### PR TITLE
Revert changes introducing CapResPeriodLength parameter

### DIFF
--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -65,8 +65,6 @@ function configure_settings(settings_path::String)
     set_default_if_absent!(settings, "MultiStage", 0)
     # No JuMP String name reporting at model generation by default, to expedite model generation; true if JuMP string names need to be enabled
     set_default_if_absent!(settings, "EnableJuMPStringNames", false)
-    set_default_if_absent!(settings, "CapResPeriodLength", 0)
-    # Capacity Reserve Period Length for storage
 
 
 return settings

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -104,17 +104,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 
 	# Capacity Reserves Margin policy
 	if setup["CapacityReserveMargin"] > 0
-		CRPL = setup["CapResPeriodLength"]
-		@variable(EP, vCAPCONTRHYDRO_DISCHARGE[y in HYDRO_RES, t=1:T]) # Hydro capacity contribution from net discharge
-		@variable(EP, vCAPCONTRHYDRO_SOC[y in HYDRO_RES, t=1:T] >= 0) # Hydro capacity contribution from charge held in reserve
-		@variable(EP, vMINSOCHYDRO[y in HYDRO_RES, t=1:T] >= 0) # Minimum SOC maintained over following n hours
-
-		@constraint(EP, cCapContrHydroEnergy[y in HYDRO_RES, t=1:T], vCAPCONTRHYDRO_DISCHARGE[y,t] <= EP[:vP][y,t])
-		@constraint(EP, cMinSocTrackHydro[y in HYDRO_RES, t=1:T, n=1:CRPL], vMINSOCHYDRO[y,t] <= EP[:vS_HYDRO][y, hoursafter(p,t,n)])
-		@constraint(EP, cCapContrHydroSOC[y in HYDRO_RES, t=1:T], vCAPCONTRHYDRO_SOC[y,t] <= dfGen[y,:Eff_Down]*vMINSOCHYDRO[y,t]/CRPL)
-		@constraint(EP, cCapContrHydroSOCPartLim[y in HYDRO_RES, t=1:T], vCAPCONTRHYDRO_SOC[y,t] <= EP[:eTotalCap][y] - vCAPCONTRHYDRO_DISCHARGE[y,t])
-
-		@expression(EP, eCapResMarBalanceHydro[res=1:inputs["NCapacityReserveMargin"], t=1:T], sum(dfGen[y,Symbol("CapRes_$res")] * (vCAPCONTRHYDRO_DISCHARGE[y,t] + vCAPCONTRHYDRO_SOC[y,t])  for y in HYDRO_RES))
+		@expression(EP, eCapResMarBalanceHydro[res=1:inputs["NCapacityReserveMargin"], t=1:T], sum(dfGen[y,Symbol("CapRes_$res")] * EP[:vP][y,t]  for y in HYDRO_RES))
 		EP[:eCapResMarBalance] += eCapResMarBalanceHydro
 	end
 

--- a/src/model/resources/storage/storage.jl
+++ b/src/model/resources/storage/storage.jl
@@ -151,18 +151,7 @@ function storage!(EP::Model, inputs::Dict, setup::Dict)
 
 	# Capacity Reserves Margin policy
 	if CapacityReserveMargin > 0
-		CRPL = setup["CapResPeriodLength"]
-		@variable(EP, vCAPCONTRSTOR_DISCHARGE[y in STOR_ALL, t=1:T]) # Storage capacity contribution from net discharge
-		@variable(EP, vCAPCONTRSTOR_SOC[y in STOR_ALL, t=1:T] >= 0) # Storage capacity contribution from charge held in reserve
-		@variable(EP, vMINSOCSTOR[y in STOR_ALL, t=1:T] >= 0) # Minimum SOC maintained over following n hours
-
-		@constraint(EP, cCapContrStorEnergy[y in STOR_ALL, t=1:T], vCAPCONTRSTOR_DISCHARGE[y,t] <= EP[:vP][y,t] - EP[:vCHARGE][y,t])
-		@constraint(EP, cMinSocTrackStor[y in STOR_ALL, t=1:T, n=1:CRPL], vMINSOCSTOR[y,t] <= EP[:vS][y, hoursafter(p,t,n)])
-		@constraint(EP, cCapContrStorSOC[y in STOR_ALL, t=1:T], vCAPCONTRSTOR_SOC[y,t] <= dfGen[y,:Eff_Down]*vMINSOCSTOR[y,t]/CRPL)
-		@constraint(EP, cCapContrStorSOCLim[y in STOR_ALL, t=1:T], vCAPCONTRSTOR_SOC[y,t] <= EP[:eTotalCap][y])
-		@constraint(EP, cCapContrStorSOCPartLim[y in STOR_ALL, t=1:T], vCAPCONTRSTOR_SOC[y,t] <= EP[:eTotalCap][y] - vCAPCONTRSTOR_DISCHARGE[y,t])
-
-		@expression(EP, eCapResMarBalanceStor[res=1:inputs["NCapacityReserveMargin"], t=1:T], sum(dfGen[y,Symbol("CapRes_$res")] * (vCAPCONTRSTOR_DISCHARGE[y,t] + vCAPCONTRSTOR_SOC[y,t])  for y in STOR_ALL))
+		@expression(EP, eCapResMarBalanceStor[res=1:inputs["NCapacityReserveMargin"], t=1:T], sum(dfGen[y,Symbol("CapRes_$res")] * (EP[:vP][y,t] - EP[:vCHARGE][y,t])  for y in STOR_ALL))
 		EP[:eCapResMarBalance] += eCapResMarBalanceStor
 	end
 

--- a/src/write_outputs/capacity_reserve_margin/write_reserve_margin_w.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_reserve_margin_w.jl
@@ -16,7 +16,6 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 
 function write_reserve_margin_w(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	T = inputs["T"]     # Number of time steps (hours)
-	p = inputs["hours_per_subperiod"]
 	#dfResMar dataframe with weights included for calculations
 	dfResMar_w = DataFrame(Constraint = [Symbol("t$t") for t in 1:T])
 	temp_ResMar_w = transpose(dual.(EP[:cCapacityResMargin]))./inputs["omega"]
@@ -26,36 +25,5 @@ function write_reserve_margin_w(path::AbstractString, inputs::Dict, setup::Dict,
 	dfResMar_w = hcat(dfResMar_w, DataFrame(temp_ResMar_w, :auto))
 	auxNew_Names_res=[Symbol("Constraint"); [Symbol("CapRes_$i") for i in 1:inputs["NCapacityReserveMargin"]]]
 	rename!(dfResMar_w,auxNew_Names_res)
-
-	maxbindinglength = 0
-	for i in 1:inputs["NCapacityReserveMargin"]
-		resmar_ts = dfResMar_w[!,Symbol("CapRes_$i")]
-		t = 1
-		currentmax = 0
-		while t <= T
-			if resmar_ts[t] > 0.1
-				if hoursbefore(p, t, 1) == (t-1)
-					currentmax += 1
-					t = t+1
-				else 
-					maxbindinglength = max(currentmax, maxbindinglength)
-					currentmax = 1
-					t = t+1
-				end
-			else
-				maxbindinglength = max(currentmax, maxbindinglength)
-				currentmax = 0
-				t = t+1
-			end
-		end
-	end
-				
-
-	println("Maximum number of consecutive binding hours for a capacity reserve margin constraint is:")
-	println(maxbindinglength)
-	println("CapResPeriodLength parameter is:")
-	println(setup["CapResPeriodLength"])
-	println("Consider adjusting CapResPeriodLength if it does not match the observed binding period length")
-
 	CSV.write(joinpath(path, "ReserveMargin_w.csv"), dfResMar_w)
 end


### PR DESCRIPTION
This is a temporary reversion to fix divide-by-zero errors and a flawed overall formulation. A future PR will introduce more comprehensive CapRes contributions for storage resources.