### PR TITLE
Fix typo in fix_initial_investments

### DIFF
--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -309,7 +309,7 @@ function fix_initial_investments(EP_prev::Model, EP_cur::Model, start_cap_d::Dic
     # and the associated linking constraint name (c) as a value
     for (e, c) in start_cap_d
         for y in keys(EP_cur[c])
-            if y in RET_CAP
+	    if y[1] in RET_CAP # extract resource integer index value from key
                 # Set the right hand side value of the linking initial capacity constraint in the current
                 # stage to the value of the available capacity variable solved for in the previous stages
                 set_normalized_rhs(EP_cur[c][y], value(EP_prev[e][y]))


### PR DESCRIPTION
y in keys(EP_cur[c]) is a DenseAxisArray key, to extract the index we need to have y[1], as already done also on line 350 in function fix_capacity_tracking.