### PR TITLE
Remove superfluous call to `haskey`

### DIFF
--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -143,7 +143,7 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict)
 
     outpath = get_default_output_folder(case)
 
-    if !haskey(mysetup, "OverwriteResults") || mysetup["OverwriteResults"] == 1
+    if mysetup["OverwriteResults"] == 1
         # Overwrite existing results if dir exists
         # This is the default behaviour when there is no flag, to avoid breaking existing code
         if !(isdir(outpath))

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -12,7 +12,7 @@ Function for the entry-point for writing the different output files. From here, 
 """
 function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dict)
 
-	if !haskey(setup, "OverwriteResults") || setup["OverwriteResults"] == 1
+	if setup["OverwriteResults"] == 1
 		# Overwrite existing results if dir exists
 		# This is the default behaviour when there is no flag, to avoid breaking existing code
 		if !(isdir(path))


### PR DESCRIPTION
Because of the new default settings, the first term in these expression always evaluates to false. They can be removed.