### PR TITLE
Add default for OverwriteResults key

### DIFF
--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -1,6 +1,7 @@
 function default_settings()
     Dict{Any,Any}(
         "PrintModel" => 0,
+        "OverwriteResults" => 0,
         "NetworkExpansion" => 0,
         "Trans_Loss_Segments" => 1,
         "Reserves" => 0,


### PR DESCRIPTION
Not overwriting results (0) is the typical setting in the examples.

...

This is something I should have included with #431.