### PR TITLE
Fixed issue #461 and bug in policy constraint slacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Order of slack policy constraint declarations (#464)
+- Sign error in the Maximum Capacity Requirement slack constraint term (#461)
+
 ## [0.3.5] - 2023-05-18
 
 ### Added

--- a/src/model/policies/cap_reserve_margin.jl
+++ b/src/model/policies/cap_reserve_margin.jl
@@ -17,11 +17,7 @@ function cap_reserve_margin!(EP::Model, inputs::Dict, setup::Dict)
 	T = inputs["T"]
 	NCRM = inputs["NCapacityReserveMargin"]
 	println("Capacity Reserve Margin Policies Module")
-
-	@constraint(EP, cCapacityResMargin[res=1:NCRM, t=1:T], EP[:eCapResMarBalance][res, t]
-				>= sum(inputs["pD"][t,z] * (1 + inputs["dfCapRes"][z,res])
-				for z=findall(x->x!=0,inputs["dfCapRes"][:,res])))
-
+	
 	# if input files are present, add capacity reserve margin slack variables
 	if haskey(inputs, "dfCapRes_slack")
 		@variable(EP,vCapResSlack[res=1:NCRM, t=1:T]>=0)
@@ -32,4 +28,10 @@ function cap_reserve_margin!(EP::Model, inputs::Dict, setup::Dict)
 		@expression(EP, eCTotalCapResSlack, sum(EP[:eCCapResSlack][res] for res = 1:NCRM))
 		EP[:eObj] += eCTotalCapResSlack
 	end
+	
+	@constraint(EP, cCapacityResMargin[res=1:NCRM, t=1:T], EP[:eCapResMarBalance][res, t]
+				>= sum(inputs["pD"][t,z] * (1 + inputs["dfCapRes"][z,res])
+				for z=findall(x->x!=0,inputs["dfCapRes"][:,res])))
+
+
 end

--- a/src/model/policies/energy_share_requirement.jl
+++ b/src/model/policies/energy_share_requirement.jl
@@ -14,10 +14,7 @@ The final term in the summation above adds roundtrip storage losses to the total
 function energy_share_requirement!(EP::Model, inputs::Dict, setup::Dict)
 
 	println("Energy Share Requirement Policies Module")
-
-	## Energy Share Requirements (minimum energy share from qualifying renewable resources) constraint
-	@constraint(EP, cESRShare[ESR=1:inputs["nESR"]], EP[:eESR][ESR] >= 0)
-
+	
 	# if input files are present, add energy share requirement slack variables
 	if haskey(inputs, "dfESR_slack")
 		@variable(EP, vESR_slack[ESR=1:inputs["nESR"]]>=0)
@@ -28,4 +25,9 @@ function energy_share_requirement!(EP::Model, inputs::Dict, setup::Dict)
 
 		EP[:eObj] += eCTotalESRSlack
 	end
+	
+	## Energy Share Requirements (minimum energy share from qualifying renewable resources) constraint
+	@constraint(EP, cESRShare[ESR=1:inputs["nESR"]], EP[:eESR][ESR] >= 0)
+
+
 end

--- a/src/model/policies/maximum_capacity_requirement.jl
+++ b/src/model/policies/maximum_capacity_requirement.jl
@@ -13,16 +13,17 @@ function maximum_capacity_requirement!(EP::Model, inputs::Dict, setup::Dict)
 	println("Maximum Capacity Requirement Module")
 	NumberOfMaxCapReqs = inputs["NumberOfMaxCapReqs"]
 
-	@constraint(EP, cZoneMaxCapReq[maxcap = 1:NumberOfMaxCapReqs], EP[:eMaxCapRes][maxcap] <= inputs["MaxCapReq"][maxcap])
-
 	# if input files are present, add maximum capacity requirement slack variables
 	if haskey(inputs, "MaxCapPriceCap")
 		@variable(EP, vMaxCap_slack[maxcap = 1:NumberOfMaxCapReqs]>=0)
-		EP[:eMaxCapRes] += vMaxCap_slack
+		EP[:eMaxCapRes] -= vMaxCap_slack
 
 		@expression(EP, eCMaxCap_slack[maxcap = 1:NumberOfMaxCapReqs], inputs["MaxCapPriceCap"][maxcap] * EP[:vMaxCap_slack][maxcap])
 		@expression(EP, eTotalCMaxCapSlack, sum(EP[:eCMaxCap_slack][maxcap] for maxcap = 1:NumberOfMaxCapReqs))
 		
 		EP[:eObj] += eTotalCMaxCapSlack
 	end
+	
+	@constraint(EP, cZoneMaxCapReq[maxcap = 1:NumberOfMaxCapReqs], EP[:eMaxCapRes][maxcap] <= inputs["MaxCapReq"][maxcap])
+
 end

--- a/src/model/policies/minimum_capacity_requirement.jl
+++ b/src/model/policies/minimum_capacity_requirement.jl
@@ -13,8 +13,6 @@ function minimum_capacity_requirement!(EP::Model, inputs::Dict, setup::Dict)
 	println("Minimum Capacity Requirement Module")
 	NumberOfMinCapReqs = inputs["NumberOfMinCapReqs"]
 
-	@constraint(EP, cZoneMinCapReq[mincap = 1:NumberOfMinCapReqs], EP[:eMinCapRes][mincap] >= inputs["MinCapReq"][mincap])
-
 	# if input files are present, add minimum capacity requirement slack variables
 	if haskey(inputs, "MinCapPriceCap")
 		@variable(EP, vMinCap_slack[mincap = 1:NumberOfMinCapReqs]>=0)
@@ -25,4 +23,8 @@ function minimum_capacity_requirement!(EP::Model, inputs::Dict, setup::Dict)
 		
 		EP[:eObj] += eTotalCMinCapSlack
 	end
+	
+	@constraint(EP, cZoneMinCapReq[mincap = 1:NumberOfMinCapReqs], EP[:eMinCapRes][mincap] >= inputs["MinCapReq"][mincap])
+
+
 end


### PR DESCRIPTION
1. `vMaxCap_slack` is now subtracted from `EP[:eMaxCapRes]` (see https://github.com/GenXProject/GenX/issues/461)
2. The definition of slack variables now precedes the constraint formulation for all policy constraints