### PR TITLE
fix bug related to writing LDES outputs when you are not using TDR

### DIFF
--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -108,7 +108,7 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 
 
 	# Output additional variables related inter-period energy transfer via storage
-	if !isempty(inputs["STOR_LONG_DURATION"])
+	if setup["TimeDomainReduction"] == 1 && !isempty(inputs["STOR_LONG_DURATION"])
 		elapsed_time_lds_init = @elapsed write_opwrap_lds_stor_init(path, inputs, setup, EP)
 		println("Time elapsed for writing lds init is")
 		println(elapsed_time_lds_init)


### PR DESCRIPTION
Currently, if you are modeling long duration storage but not using any time domain reduction, GenX will encounter an error when writing the outputs, because the data related to TDR (i.e. PeriodMap) does not exist. This changes fixes the issue by only printing LDES specific outputs when TDR is being used. NOTE: this means that LDES outputs will not be printed if the user is inputting data with TDR already performed (is there a better way to do this?).