### PR TITLE
Add output for dual of capacity constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add output for dual of capacity constraint (#473)
+
 ## [0.3.6] - 2023-08-01
 
 ### Fixed
@@ -22,9 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Eliminate 'Axis contains one element' warning (seen when LDS is used) by combining two constraints (#496).
-
-### Added
-- Add output for dual of capacity constraint (#473)
 
 ## [0.3.5] - 2023-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Eliminate 'Axis contains one element' warning (seen when LDS is used) by combining two constraints (#496).
 
+### Added
+- Add output for dual of capacity constraint (#473)
+
 ## [0.3.5] - 2023-05-18
 
 ### Added

--- a/docs/src/data_documentation.md
+++ b/docs/src/data_documentation.md
@@ -560,6 +560,7 @@ Reports optimal values of investment variables (except StartCap, which is an inp
 | RetCap |Retired power capacity of each resource type in each zone |MW |
 | NewCap |Installed capacity of each resource type in each zone |MW|
 | EndCap| Total power capacity of each resource type in each zone |MW |
+| CapacityConstraintDual |Shadow price of the capacity limit set by Max_Cap_MW for each resource type in each zone. Values are multiplied by -1 so that the output is >=0. |$/MW |
 | StartEnergyCap |Initial energy capacity of each resource type in each zone; this is an input and applies only to storage tech.| MWh |
 | RetEnergyCap |Retired energy capacity of each resource type in each zone; applies only to storage tech. |MWh |
 | NewEnergyCap| Installed energy capacity of each resource type in each zone; applies only to storage tech. |MWh |

--- a/src/write_outputs/write_capacity.jl
+++ b/src/write_outputs/write_capacity.jl
@@ -26,6 +26,11 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 		end
 	end
 
+	capacity_constraint_dual = fill(NaN, size(inputs["RESOURCES"]))
+	for y in dfGen[dfGen.Max_Cap_MW.>0, :R_ID]
+		capacity_constraint_dual[y] = dual.(EP[:cMaxCap][y])
+	end
+
 	capcharge = zeros(size(inputs["RESOURCES"]))
 	retcapcharge = zeros(size(inputs["RESOURCES"]))
 	existingcapcharge = zeros(size(inputs["RESOURCES"]))
@@ -57,6 +62,7 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 		RetCap = retcapdischarge[:],
 		NewCap = capdischarge[:],
 		EndCap = value.(EP[:eTotalCap]),
+		CapacityConstraintDual = capacity_constraint_dual[:],
 		StartEnergyCap = existingcapenergy[:],
 		RetEnergyCap = retcapenergy[:],
 		NewEnergyCap = capenergy[:],
@@ -71,6 +77,7 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 		dfCap.RetCap = dfCap.RetCap * ModelScalingFactor
 		dfCap.NewCap = dfCap.NewCap * ModelScalingFactor
 		dfCap.EndCap = dfCap.EndCap * ModelScalingFactor
+		dfCap.CapacityConstraintDual = dfCap.CapacityConstraintDual * ModelScalingFactor
 		dfCap.StartEnergyCap = dfCap.StartEnergyCap * ModelScalingFactor
 		dfCap.RetEnergyCap = dfCap.RetEnergyCap * ModelScalingFactor
 		dfCap.NewEnergyCap = dfCap.NewEnergyCap * ModelScalingFactor
@@ -84,6 +91,7 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 			Resource = "Total", Zone = "n/a",
 			StartCap = sum(dfCap[!,:StartCap]), RetCap = sum(dfCap[!,:RetCap]),
 			NewCap = sum(dfCap[!,:NewCap]), EndCap = sum(dfCap[!,:EndCap]),
+			CapacityConstraintDual = NaN,
 			StartEnergyCap = sum(dfCap[!,:StartEnergyCap]), RetEnergyCap = sum(dfCap[!,:RetEnergyCap]),
 			NewEnergyCap = sum(dfCap[!,:NewEnergyCap]), EndEnergyCap = sum(dfCap[!,:EndEnergyCap]),
 			StartChargeCap = sum(dfCap[!,:StartChargeCap]), RetChargeCap = sum(dfCap[!,:RetChargeCap]),

--- a/src/write_outputs/write_capacity.jl
+++ b/src/write_outputs/write_capacity.jl
@@ -26,7 +26,7 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 		end
 	end
 
-	capacity_constraint_dual = fill(NaN, size(inputs["RESOURCES"]))
+	capacity_constraint_dual = zeros(size(inputs["RESOURCES"]))
 	for y in dfGen[dfGen.Max_Cap_MW.>0, :R_ID]
 		capacity_constraint_dual[y] = dual.(EP[:cMaxCap][y])
 	end
@@ -91,7 +91,7 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 			Resource = "Total", Zone = "n/a",
 			StartCap = sum(dfCap[!,:StartCap]), RetCap = sum(dfCap[!,:RetCap]),
 			NewCap = sum(dfCap[!,:NewCap]), EndCap = sum(dfCap[!,:EndCap]),
-			CapacityConstraintDual = NaN,
+			CapacityConstraintDual = "n/a",
 			StartEnergyCap = sum(dfCap[!,:StartEnergyCap]), RetEnergyCap = sum(dfCap[!,:RetEnergyCap]),
 			NewEnergyCap = sum(dfCap[!,:NewEnergyCap]), EndEnergyCap = sum(dfCap[!,:EndEnergyCap]),
 			StartChargeCap = sum(dfCap[!,:StartChargeCap]), RetChargeCap = sum(dfCap[!,:RetChargeCap]),

--- a/src/write_outputs/write_capacity.jl
+++ b/src/write_outputs/write_capacity.jl
@@ -27,8 +27,10 @@ function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Mod
 	end
 
 	capacity_constraint_dual = zeros(size(inputs["RESOURCES"]))
-	for y in dfGen[dfGen.Max_Cap_MW.>0, :R_ID]
-		capacity_constraint_dual[y] = dual.(EP[:cMaxCap][y])
+	if :Max_Cap_MW in propertynames(dfGen)
+		for y in dfGen[dfGen.Max_Cap_MW.>0, :R_ID]
+			capacity_constraint_dual[y] = -dual.(EP[:cMaxCap][y])
+		end
 	end
 
 	capcharge = zeros(size(inputs["RESOURCES"]))


### PR DESCRIPTION
In many studies, users wish to know the dual (shadow price) of the capacity constraint for a given resource or set of resources. This change adds this to an existing output file.