### PR TITLE
Update investment_discharge.jl with correct expression for FOM cost

### DIFF
--- a/src/model/core/discharge/investment_discharge.jl
+++ b/src/model/core/discharge/investment_discharge.jl
@@ -28,7 +28,7 @@ In addition, this function adds investment and fixed O\&M related costs related 
 \begin{aligned}
 & 	\sum_{y \in \mathcal{G} } \sum_{z \in \mathcal{Z}}
 	\left( (\pi^{INVEST}_{y,z} \times \overline{\Omega}^{size}_{y,z} \times  \Omega_{y,z})
-	+ (\pi^{FOM}_{y,z} \times \overline{\Omega}^{size}_{y,z} \times  \Delta^{total}_{y,z})\right)
+	+ (\pi^{FOM}_{y,z} \times  \Delta^{total}_{y,z})\right)
 \end{aligned}
 ```
 """


### PR DESCRIPTION
This is a minot but significant change in the documentation page for investment discharge. Currently, the expression for FOM cost wrongly includes the term `\overline{\Omega}^{size}_{y,z}` multiplied by the total capacity. However, this term only needs to be multiplied by the new-built or newly retired capacities for the units that participate in Unit Commitment (because of clustering). The FOM is calculated for total capacity, which also includes existing capacity and hence this term shouldn't be there. The code is correct. But, the documentation is not. This PR will fix the documentation.