### PR TITLE
Fix HiGHS solver setting error (solves Issue #489)

### DIFF
--- a/src/configure_solver/configure_highs.jl
+++ b/src/configure_solver/configure_highs.jl
@@ -241,10 +241,6 @@ The HiGHS optimizer instance is configured with the following default parameters
 	# [type: HighsInt, advanced: true, range: {0, 20}, default: 0]
 	allowed_cost_scale_factor: 0
 	
-	# Strategy for dualising before simplex
-	# [type: HighsInt, advanced: true, range: {-1, 1}, default: -1]
-	simplex_dualise_strategy: -1
-	
 	# Strategy for permuting before simplex
 	# [type: HighsInt, advanced: true, range: {-1, 1}, default: -1]
 	simplex_permute_strategy: -1
@@ -402,7 +398,6 @@ function configure_highs(solver_settings_path::String)
         "cost_scale_factor" => 0,
         "allowed_matrix_scale_factor" => 20,
         "allowed_cost_scale_factor" => 0,
-        "simplex_dualise_strategy" => -1,
         "simplex_permute_strategy" => -1,
         "max_dual_simplex_cleanup_level" => 1,
         "max_dual_simplex_phase1_cleanup_level" => 2,


### PR DESCRIPTION
Removes "simplex_dualise_strategy" setting which is no longer compatible with HiGHS v1.5