### PR TITLE
Fix warning during LDES constraint construction

### DIFF
--- a/src/model/resources/storage/long_duration_storage.jl
+++ b/src/model/resources/storage/long_duration_storage.jl
@@ -103,7 +103,7 @@ function long_duration_storage!(EP::Model, inputs::Dict)
 					vSOCw[y,r+1] == vSOCw[y,r] + vdSOC[y,dfPeriodMap[r,:Rep_Period_Index]])
 
 	## Last period is linked to first period
-	@constraint(EP, cSoCBalLongDurationStorageEnd[y in STOR_LONG_DURATION, r in MODELED_PERIODS_INDEX[end]],
+	@constraint(EP, cSoCBalLongDurationStorageEnd[y in STOR_LONG_DURATION, r in [MODELED_PERIODS_INDEX[end]]],
 					vSOCw[y,1] == vSOCw[y,r] + vdSOC[y,dfPeriodMap[r,:Rep_Period_Index]])
 
 	# Storage at beginning of each modeled period cannot exceed installed energy capacity


### PR DESCRIPTION
Currently, when using LDES resources, GenX will throw a warning when constructing one of the LDES constraints. This warning happens because one of the sets in the affected constraint is a set containing one element, and JuMP throws a warning when this happens. The proposed fix adds brackets around the 1-element set to clarify that this behavior is intentional, consistent with the suggestion in the warning thrown by JuMP.

Note that there are no errors in the current formulation. I am only proposing this fix so that users do not see this concerning warning.