### PR TITLE
Check COMMIT_ZONE is not empty before trying to access

### DIFF
--- a/src/write_outputs/write_costs.jl
+++ b/src/write_outputs/write_costs.jl
@@ -93,7 +93,7 @@ function write_costs(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 			tempCTotal += eCVarFlex_in
 		end
 
-		if setup["UCommit"] >= 1
+		if setup["UCommit"] >= 1 && !isempty(COMMIT_ZONE)
 			eCStart = sum(value.(EP[:eCStart][COMMIT_ZONE,:]))
 			tempCStart += eCStart
 			tempCTotal += eCStart


### PR DESCRIPTION
I came across a "LoadError: MethodError: reducing over an empty collection is not allowed" error on write_costs.jl:97 in GenX 0.3.5. Adding "&& !isempty(COMMIT_ZONE)" to line 96 allowed the data output to finish. Feel free to fix another way if the approach makes more sense.