### PR TITLE
Fix error on write_costs re: COMMIT_ZONE #506

### DIFF
--- a/src/write_outputs/write_costs.jl
+++ b/src/write_outputs/write_costs.jl
@@ -93,7 +93,7 @@ function write_costs(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 			tempCTotal += eCVarFlex_in
 		end
 
-		if setup["UCommit"] >= 1
+		if setup["UCommit"] >= 1 && !isempty(COMMIT_ZONE)
 			eCStart = sum(value.(EP[:eCStart][COMMIT_ZONE,:]))
 			tempCStart += eCStart
 			tempCTotal += eCStart


### PR DESCRIPTION
Prevent an error when there are no resources with COMMIT in a given zone. This addresses @wrgunther 's issue, #506 .