### PR TITLE
Return path from write_outputs

### DIFF
--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -69,7 +69,7 @@ function run_genx_case_simple!(case::AbstractString, mysetup::Dict)
     # Run MGA if the MGA flag is set to 1 else only save the least cost solution
     println("Writing Output")
     outputs_path = get_default_output_folder(case)
-    elapsed_time = @elapsed write_outputs(EP, outputs_path, mysetup, myinputs)
+    elapsed_time = @elapsed outputs_path = write_outputs(EP, outputs_path, mysetup, myinputs)
     println("Time elapsed for writing is")
     println(elapsed_time)
     if mysetup["ModelingToGenerateAlternatives"] == 1

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -3,7 +3,7 @@
 ##
 ## description: Writes results to multiple .csv output files in path directory
 ##
-## returns: n/a
+## returns: path directory
 ################################################################################
 @doc raw"""
 	write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dict)
@@ -16,12 +16,12 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 		# Overwrite existing results if dir exists
 		# This is the default behaviour when there is no flag, to avoid breaking existing code
 		if !(isdir(path))
-		mkdir(path)
+		mkpath(path)
 		end
 	else
 		# Find closest unused ouput directory name and create it
 		path = choose_output_dir(path)
-		mkdir(path)
+		mkpath(path)
 	end
 
 	# https://jump.dev/MathOptInterface.jl/v0.9.10/apireference/#MathOptInterface.TerminationStatusCode
@@ -174,5 +174,7 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 	end
 	## Print confirmation
 	println("Wrote outputs to $path")
+
+	return path
 
 end # END output()


### PR DESCRIPTION
write_outputs now returns the path where the results were saved after any changes by choose_output_dir()

I also changed mkdir() to mkpath, to avoid errors were a parent directory of the intended results folder is missing.

Finally, I updated the mga outputs_path folder to be the folder created by  choose_output_dir(), not the original outputs_path