### PR TITLE
Remove coveralls and coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,13 @@ julia:
   - 1.6
   - 1.7
   - 1.8
-  #- 1.9
-  - nightly
-coveralls: true
+  - 1.9
 branches:
   only:
     - main
     - gh-pages
 os:
   - linux
-  #- osx
 arch:
   - x64
 cache:
@@ -23,8 +20,6 @@ cache:
     - ~/.julia/artifacts
 jobs:
   fast_finish: true
-  allow_failures:
-   # - julia: nightly
   include:
     - stage: Documentation
       julia: 1.6
@@ -39,17 +34,3 @@ jobs:
           doctest(GenX)
           include("docs/make.jl")'
       after_success: skip
-after_success:
-  - |
-    julia -e '
-      using Pkg
-      Pkg.add("Coverage")
-      using Coverage
-      Codecov.submit(process_folder())'
-  - |
-    julia -e '
-      using Pkg
-      Pkg.add("Coverage")
-      using Coverage
-      Coveralls.submit(process_folder())'
-#install: travis_wait 30 mvn install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # GenX 
 [![Build Status](https://travis-ci.com/GenXProject/GenX.svg?branch=main)](https://travis-ci.com/GenXProject/GenX)
-[![Coverage Status](https://coveralls.io/repos/github/GenXProject/GenX/badge.svg?branch=main)](https://coveralls.io/github/GenXProject/GenX?branch=main)
 <!---[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://genxproject.github.io/GenX/stable) -->
 <!---[![Documentation Build](https://img.shields.io/badge/docs-stable-blue.svg](https://genxproject.github.io/GenX/stable) -->
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://genxproject.github.io/GenX/dev)


### PR DESCRIPTION
These are causing the build to fail and we don't have any tests, so they were pretty pointless. Without this we can at least see if the builds succeed.