### PR TITLE
Disable Retrofits feature

### DIFF
--- a/Example_Systems/RetrofitExample/RetrofitExample_MultiStage/README.txt
+++ b/Example_Systems/RetrofitExample/RetrofitExample_MultiStage/README.txt
@@ -1,5 +1,5 @@
 This example requires an experimental feature which is *deactivated* because it is under development.
-To reactivate the feature, comment the relevant line in load_generators_data!.
+To reactivate the feature, comment out the relevant line in load_generators_data!.
 
 Multi-Stage Retrofit Example
 ----------------------------

--- a/Example_Systems/RetrofitExample/RetrofitExample_MultiStage/README.txt
+++ b/Example_Systems/RetrofitExample/RetrofitExample_MultiStage/README.txt
@@ -1,5 +1,9 @@
+This example requires an experimental feature which is *deactivated* because it is under development.
+To reactivate the feature, comment the relevant line in load_generators_data!.
+
 Multi-Stage Retrofit Example
 ----------------------------
+
 Description: One zone, few technologies, retrofit options include CCS, H2, SMR, and TES.
 
 All changes necessary in the inputs in enable retrofit modeling are located in Generators_data.csv.

--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -61,6 +61,10 @@ function load_generators_data!(setup::Dict, path::AbstractString, inputs_gen::Di
 	end
 		
 	inputs_gen["RETRO"] = gen_in[gen_in.RETRO.==1,:R_ID]
+    # Disable Retrofit while it's under development
+    if !(isempty(inputs_gen["RETRO"]))
+        error("The Retrofits feature, which is activated by nonzero data in a 'RETRO' column in Generators_data.csv, is under development and is not ready for public use. Disable this message to enable this *experimental* feature.")
+    end
 
 	# Set of thermal generator resources
 	if setup["UCommit"]>=1


### PR DESCRIPTION
The Retrofits feature is still under development, so it is being disabled. In order to re-enable the feature, remove the line from load_generators_data! which sets RETRO to be an empty Vector.