### PR TITLE
Bug fix and simplify expression_manipulations.jl

### DIFF
--- a/src/model/expression_manipulation.jl
+++ b/src/model/expression_manipulation.jl
@@ -1,29 +1,27 @@
-function createemptyexpression!(EP::Model, exprname::Symbol, dim1::Int64)
-    temp = Vector{AffExpr}(undef, dim1)
-    for i=1:dim1::Int64
-        temp[i] = AffExpr(0.0)
-    end
-    EP[exprname] = temp
+###### ###### ###### ###### ###### ######
+# Create dense arrays of expressions filled with zeros to be added to later
+###### ###### ###### ###### ###### ######
+
+function create_empty_expression!(EP::Model, exprname::Symbol)
+    EP[exprname] = AffExpr(0.0)
+    return nothing
 end
 
-function createemptyexpression!(EP::Model, exprname::Symbol, dim1::Int64, dim2::Int64)
-    temp = Matrix{AffExpr}(undef, (dim1, dim2))
-    for j=1:dim2
-        for i=1:dim1
-            temp[i,j] = AffExpr(0.0)
-        end
-    end
+function create_empty_expression!(EP::Model, exprname::Symbol, dim1::Int64)
+    temp = Array{AffExpr}(undef, dim1)
+    fill_with_zeros!(temp)
     EP[exprname] = temp
+    return nothing
 end
 
-function createemptyexpression!(EP::Model, exprname::Symbol, dims::NTuple{N, Int64}) where N
+function create_empty_expression!(EP::Model, exprname::Symbol, dims::NTuple{N, Int64}) where N
     temp = Array{AffExpr}(undef, dims)
     fill_with_zeros!(temp)
     EP[exprname] = temp
     return nothing
 end
 
-function createemptyexpression!(EP::Model, exprname::Symbol, dims::Vector{Int64})
+function create_empty_expression!(EP::Model, exprname::Symbol, dims::Vector{Int64})
     # The version using tuples is slightly less memory
     temp = Array{AffExpr}(undef, dims...)
     fill_with_zeros!(temp)
@@ -31,21 +29,35 @@ function createemptyexpression!(EP::Model, exprname::Symbol, dims::Vector{Int64}
     return nothing
 end
 
-function fill_with_zeros!(arr::Array{AffExpr, dims}) where dims
+###### ###### ###### ###### ###### ######
+# Fill dense arrays of expressions with zeros or a constant
+###### ###### ###### ###### ###### ######
+
+function fill_with_zeros!(arr::Array{GenericAffExpr{C,T}, dims}) where {C,T,dims}
     for i::Int64 in eachindex(IndexLinear(), arr)::Base.OneTo{Int64}
         arr[i] = AffExpr(0.0)
     end
     return nothing
 end
 
-function fill_with_const!(arr::Array{AffExpr, dims}, con::Float64) where dims
+function fill_with_const!(arr::Array{GenericAffExpr{C,T}, dims}, con::Real) where {C,T,dims}
     for i::Int64 in eachindex(IndexLinear(), arr)::Base.OneTo{Int64}
         arr[i] = AffExpr(con)
     end
     return nothing
 end
 
-function _add_similar_to_expression!(expr1::Array{C, dim1}, expr2::Array{T, dim2}) where {C,T,dim1,dim2}
+###### ###### ###### ###### ###### ######
+# Element-wise addition of one expression into another
+# Both arrays must have the same dimensions
+###### ###### ###### ###### ###### ######
+
+function add_similar_to_expression!(expr1::GenericAffExpr{C,T}, expr2::V) where {C,T,V}
+    add_to_expression!(expr1, expr2)
+    return nothing
+end
+
+function add_similar_to_expression!(expr1::Array{GenericAffExpr{C,T}, dim1}, expr2::Array{V, dim2}) where {C,T,V,dim1,dim2}
     # This is defined for Arrays of different dimensions
     # despite the fact it will definitely throw an error
     # because the error will tell the user / developer
@@ -57,46 +69,47 @@ function _add_similar_to_expression!(expr1::Array{C, dim1}, expr2::Array{T, dim2
     return nothing
 end
 
-function add_similar_to_expression!(expr1::Array{GenericAffExpr{C,T}, dim1}, expr2::Array{GenericAffExpr{C,T}, dim2}) where {C,T,dim1,dim2}
-    _add_similar_to_expression!(expr1, expr2)
+function add_similar_to_expression!(expr1::AbstractArray{GenericAffExpr{C,T}, dim1}, expr2::AbstractArray{V, dim2}) where {C,T,V,dim1,dim2}
+    # This is defined for Arrays of different dimensions
+    # despite the fact it will definitely throw an error
+    # because the error will tell the user / developer
+    # the dimensions of both arrays
+    check_sizes_match(expr1, expr2)
+    for i in eachindex(expr1)
+        add_to_expression!(expr1[i], expr2[i])
+    end
+    return nothing
 end
 
-function add_similar_to_expression!(expr1::Array{GenericAffExpr{C,T}, dim1}, expr2::Array{GenericVariableRef{C}, dim2}) where {C,T,dim1,dim2}
-    _add_similar_to_expression!(expr1, expr2)
+###### ###### ###### ###### ###### ######
+# Element-wise addition of one term into an expression
+# Both arrays must have the same dimensions
+###### ###### ###### ###### ###### ######
+
+function add_term_to_expression!(expr1::GenericAffExpr{C,T}, expr2::V) where {C,T,V}
+    add_to_expression!(expr1, expr2)
+    return nothing
 end
 
-function add_similar_to_expression!(expr1::Array{GenericAffExpr{C,T}, dim1}, expr2::Array{AbstractJuMPScalar, dim2}) where {C,T,dim1,dim2}
-    _add_similar_to_expression!(expr1, expr2)
-end
-
-function add_similar_to_expression!(expr1::Array{GenericAffExpr{C,T}, dim1}, expr2::Array{Float64, dim2}) where {C,T,dim1,dim2}
-    _add_similar_to_expression!(expr1, expr2)
-end
-
-function _add_term_to_expression!(expr1::Array{C, dims}, expr2::T) where {C,T,dims}
+function add_term_to_expression!(expr1::Array{GenericAffExpr{C,T}, dims}, expr2::V) where {C,T,V,dims}
     for i in eachindex(IndexLinear(), expr1)
         add_to_expression!(expr1[i], expr2)
     end
     return nothing
 end
 
-function add_term_to_expression!(expr1::Array{GenericAffExpr{C,T}, dims}, expr2::Float64) where {C,T,dims}
-    _add_term_to_expression!(expr1, expr2)
+function add_term_to_expression!(expr1::AbstractArray{GenericAffExpr{C,T}, dims}, expr2::V) where {C,T,V,dims}
+    for i in eachindex(expr1)
+        add_to_expression!(expr1[i], expr2)
+    end
+    return nothing
 end
 
-function add_term_to_expression!(expr1::Array{GenericAffExpr{C,T}, dims}, expr2::GenericAffExpr{C,T}) where {C,T,dims}
-    _add_term_to_expression!(expr1, expr2)
-end
+###### ###### ###### ###### ###### ######
+# Check that two arrays have the same dimensions
+###### ###### ###### ###### ###### ######
 
-function add_term_to_expression!(expr1::Array{GenericAffExpr{C,T}, dims}, expr2::GenericVariableRef{C}) where {C,T,dims}
-    _add_term_to_expression!(expr1, expr2)
-end
-
-function add_term_to_expression!(expr1::Array{GenericAffExpr{C,T}, dims}, expr2::AbstractJuMPScalar) where {C,T,dims}
-    _add_term_to_expression!(expr1, expr2)
-end
-
-function check_sizes_match(expr1::Array{C, dim1}, expr2::Array{T, dim2}) where {C,T,dim1, dim2}
+function check_sizes_match(expr1::AbstractArray{C, dim1}, expr2::AbstractArray{T, dim2}) where {C,T,dim1, dim2}
     # After testing, this appears to be just as fast as a method for Array{GenericAffExpr{C,T}, dims} or Array{AffExpr, dims}
     if size(expr1) != size(expr2)
         error("
@@ -105,7 +118,11 @@ function check_sizes_match(expr1::Array{C, dim1}, expr2::Array{T, dim2}) where {
     end
 end
 
-function _sum_expression(expr::AbstractArray{C, dims}) where {C,dims}
+###### ###### ###### ###### ###### ######
+# Sum an array of expressions into a single expression
+###### ###### ###### ###### ###### ######
+
+function sum_expression(expr::AbstractArray{C, dims}) where {C,dims}
     # This appears to work just as well as a separate method for Array{AffExpr, dims}
     total = AffExpr(0.0)
     for i in eachindex(expr)

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -88,29 +88,29 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 
 	# Initialize Power Balance Expression
 	# Expression for "baseline" power balance constraint
-	createemptyexpression!(EP, :ePowerBalance, T, Z)
+	create_empty_expression!(EP, :ePowerBalance, (T, Z))
 
 	# Initialize Objective Function Expression
 	EP[:eObj] = AffExpr(0.0)
 
-	createemptyexpression!(EP, :eGenerationByZone, Z, T)
+	create_empty_expression!(EP, :eGenerationByZone, (Z, T))
 	
 	# Initialize Capacity Reserve Margin Expression
 	if setup["CapacityReserveMargin"] > 0
-		createemptyexpression!(EP, :eCapResMarBalance, inputs["NCapacityReserveMargin"], T)
+		create_empty_expression!(EP, :eCapResMarBalance, (inputs["NCapacityReserveMargin"], T))
 	end
 
 	# Energy Share Requirement
 	if setup["EnergyShareRequirement"] >= 1
-		createemptyexpression!(EP, :eESR, inputs["nESR"])
+		create_empty_expression!(EP, :eESR, inputs["nESR"])
 	end
 
 	if setup["MinCapReq"] == 1
-		createemptyexpression!(EP, :eMinCapRes, inputs["NumberOfMinCapReqs"])
+		create_empty_expression!(EP, :eMinCapRes, inputs["NumberOfMinCapReqs"])
 	end
 
 	if setup["MaxCapReq"] == 1
-		createemptyexpression!(EP, :eMaxCapRes, inputs["NumberOfMaxCapReqs"])
+		create_empty_expression!(EP, :eMaxCapRes, inputs["NumberOfMaxCapReqs"])
 	end
 
 	# Infrastructure

--- a/test/expression_manipulation_test.jl
+++ b/test/expression_manipulation_test.jl
@@ -14,14 +14,14 @@ let
     GenX.fill_with_const!(small_const_expr, 6.0)
     @test small_const_expr == AffExpr.([6.0 6.0; 6.0 6.0; 6.0 6.0])
 
-    # Test createemptyexpression! with fill_with_const!
+    # Test create_empty_expression! with fill_with_const!
     large_dims = (2,10,20)
-    GenX.createemptyexpression!(EP, :large_expr, large_dims)
+    GenX.create_empty_expression!(EP, :large_expr, large_dims)
     @test all(EP[:large_expr] .== 0.0)
 
-    # Test createemptyexpression! with fill_with_const!
+    # Test create_empty_expression! with fill_with_const!
     large_dims_vector = collect(large_dims)
-    GenX.createemptyexpression!(EP, :large_const_expr, large_dims)
+    GenX.create_empty_expression!(EP, :large_const_expr, large_dims)
     GenX.fill_with_const!(EP[:large_const_expr], 6.0)
     @test all(EP[:large_const_expr] .== 6.0)
 
@@ -33,7 +33,7 @@ let
     @test all(EP[:large_expr][:] .== 18.0)
 
     # Test add_similar_to_expression! returns an error if the dimensions don't match
-    GenX.createemptyexpression!(EP, :small_expr, (2,3))
+    GenX.create_empty_expression!(EP, :small_expr, (2,3))
     @test_throws ErrorException GenX.add_similar_to_expression!(EP[:large_expr], EP[:small_expr])
 
     # Test we can add variables to an expression using add_similar_to_expression!
@@ -64,8 +64,8 @@ end
 
 # function test_performance(expr_dims)
 #     EP = Model(HiGHS.Optimizer)
-#     GenX.createemptyexpression!(EP, :e, expr_dims)
-#     GenX.createemptyexpression!(EP, :r, expr_dims)
+#     GenX.create_empty_expression!(EP, :e, expr_dims)
+#     GenX.create_empty_expression!(EP, :r, expr_dims)
 #     GenX.fill_with_const!(EP[:r], 6.0)
 #     @code_warntype GenX._add_similar_to_expression!(EP[:e], EP[:r])
 #     @code_warntype GenX.add_similar_to_expression!(EP[:e], EP[:r])


### PR DESCRIPTION
@gmantegna identified some bugs on the develop branch after PR #498 . I had missed combinations of types in how I defined `add_similar_to_expression!()`. To fix this and try to reduce the chances of the same happening in the future, I've already:

- Abstracted the method definitions so that we don't have to explicitly define every combination. This should also hopefully reduce code maintenance requirements in the future as we use new types.
- `add_similar_to_expression()` and most of the other functions are now defined for single entry expressions as opposed to only arrays of expressions.
- `add_similar_to_expression()` is also defined for AbstractArrays, such as expressions which have indices which don't go from 1:length(array)
- `createemptyexpression()` is replaced with `create_empty_expression()` to make the naming consistent with other GenX functions.
- I'm in the process of updating the tests in expression_manipulation_tests.jl

This branch appears to work for all the SmallNewEngland and RealNewEngland examples, so others are encouraged to try it out. I'm trying to test this branch on a much wider range of problems to catch bugs. I'm also rerunning the performance comparison. I'll add a task list shortly.





- 