### PR TITLE
Bug Fix for correct tracking of current investment stage by SDDP

### DIFF
--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -82,6 +82,7 @@ function run_ddp(models_d::Dict, setup::Dict, inputs_d::Dict)
 
     # Step a.i) Initialize cost-to-go function for t = 1:num_stages
     for t in 1:num_stages
+	settings_d["CurStage"] = t;
         models_d[t] = initialize_cost_to_go(settings_d, models_d[t], inputs_d[t])
     end
 


### PR DESCRIPTION
The value of `mysetup["CurrStage"]` is modified in `run_genx_case_multistage!` inside a for loop. The dictionary `mysetup` is then passed to function `run_ddp` as `setup_d` and the current stage value is used by function `initialize_cost_to_go` but it is not updated to match the current stage, and left set to the last stage as done by parent function  `run_genx_case_multistage!`. 

This commit fixes that and set the right current stage in `setup_d` before initializing the cost-to-go.