### PR TITLE
Added computation of cumulative minimum capacity retirements in multistage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix name of Fixed_OM_Cost_Charge_per_MWyr when reading from Generators_data in multistage code. (#533)
   Previously there was a typo in this in the multistage code that led to a silent bug, which affects outputs,
   for anyone running non-myopic multistage GenX with asymmetric storage.
+- Fix computation of cumulative minimum capacity retirements in multistage GenX (#514)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -130,6 +130,8 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict)
         inputs_dict[t] = load_inputs(mysetup, inpath_sub)
         inputs_dict[t] = configure_multi_stage_inputs(inputs_dict[t],mysetup["MultiStageSettingsDict"],mysetup["NetworkExpansion"])
 
+        compute_cumulative_min_retirements!(inputs_dict,t)
+
         # Step 2) Generate model
         model_dict[t] = generate_model(mysetup, inputs_dict[t], OPTIMIZER)
     end


### PR DESCRIPTION
Fixed computation of cumulative minimum retirements in multistage code. Previously, minimum capacity retirement parameters were not added up and this resulted in the minimum retirement constraints enforcing wrong lower bounds ( #514 )