### PR TITLE
Change ModelParameterScale to const

### DIFF
--- a/src/GenX.jl
+++ b/src/GenX.jl
@@ -52,7 +52,7 @@ using Cbc
 # To translate MW to GW, divide by ModelScalingFactor
 # To translate $ to $M, multiply by ModelScalingFactor^2
 # To translate $/MWh to $M/GWh, multiply by ModelScalingFactor
-ModelScalingFactor = 1e+3
+const ModelScalingFactor = 1e+3
 
 # thanks, ChatGPT
 function include_all_in_folder(folder)


### PR DESCRIPTION
"const is used to declare global variables whose values will not change. In almost all code (and particularly performance sensitive code) global variables should be declared constant in this way." 

https://docs.julialang.org/en/v1/base/base/#const