### PR TITLE
Fix eELOSSByZone expr: access before initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously there was a typo in this in the multistage code that led to a silent bug, which affects outputs,
   for anyone running non-myopic multistage GenX with asymmetric storage.
 - Fix computation of cumulative minimum capacity retirements in multistage GenX (#514)
+- Fix access of eELOSSByZone expr before initialization (#541)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -95,6 +95,9 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 
 	create_empty_expression!(EP, :eGenerationByZone, (Z, T))
 	
+	# Energy losses related to technologies
+	create_empty_expression!(EP, :eELOSSByZone, Z)
+	
 	# Initialize Capacity Reserve Margin Expression
 	if setup["CapacityReserveMargin"] > 0
 		create_empty_expression!(EP, :eCapResMarBalance, (inputs["NCapacityReserveMargin"], T))
@@ -127,7 +130,6 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	fuel!(EP, inputs, setup)
 
 	co2!(EP, inputs) 
-
 
 	if setup["Reserves"] > 0
 		reserves!(EP, inputs, setup)

--- a/src/model/resources/storage/storage_all.jl
+++ b/src/model/resources/storage/storage_all.jl
@@ -128,10 +128,9 @@ function storage_all!(EP::Model, inputs::Dict, setup::Dict)
 		end
 	end
 
-	#From CO2 Policy module
-	@expression(EP, eELOSSByZone[z=1:Z],
-		sum(EP[:eELOSS][y] for y in intersect(STOR_ALL, dfGen[dfGen[!,:Zone].==z,:R_ID]))
-	)
+	# From CO2 Policy module
+	expr = @expression(EP, [z=1:Z], sum(EP[:eELOSS][y] for y in intersect(STOR_ALL, dfGen[dfGen[!,:Zone].==z,:R_ID])))
+	add_similar_to_expression!(EP[:eELOSSByZone], expr)
 
 	# Capacity Reserve Margin policy
 	if CapacityReserveMargin > 0

--- a/src/model/resources/vre_stor/vre_stor.jl
+++ b/src/model/resources/vre_stor/vre_stor.jl
@@ -1166,11 +1166,7 @@ function stor_vre_stor!(EP::Model, inputs::Dict, setup::Dict)
     # From CO2 Policy module
 	@expression(EP, eELOSSByZone_VRE_STOR[z=1:Z],
         sum(EP[:eELOSS_VRE_STOR][y] for y in intersect(dfVRE_STOR[(dfVRE_STOR[!,:Zone].==z),:R_ID],STOR)))
-    if !isempty(inputs["STOR_ALL"])
-        EP[:eELOSSByZone] += eELOSSByZone_VRE_STOR
-    else
-        @expression(EP, eELOSSByZone[z=1:Z], eELOSSByZone_VRE_STOR[z])
-    end
+    add_similar_to_expression!(EP[:eELOSSByZone], eELOSSByZone_VRE_STOR)
 
     ### CONSTRAINTS ###
 


### PR DESCRIPTION
## Description
This fixes #541. 
The expression `eELOSSByZone` is accessed in `co2_cap.jl` without being initialized if no storage is present in the model. 

## What type of PR is this? (check all applicable)

- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Code Refactor
- [ ] Performance Improvements

## Related Tickets & Documents
<!-- 
Please use this format to link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [X] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [X] Code has been tested to ensure all functionality works as intended.
- [X] CHANGELOG.md has been updated (if this is a 'notable' change).
- [X] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
Run `Example_Systems/SmallNewEngland/OneZone/Run.j`. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop