### PR TITLE
Fix eELOSSByZone expr: access before initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README with new instructions for running GenX through Julia REPL terminal (#492)
 - Fix factor of 0.5 when writing out transmission losses. (#480)
 - Fix summation error when a set of hours is empty (in thermal_commit.jl).
+- Fix access to eELOSSByZone expr before initialization (#541)
 
 ### Changed
 

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -93,9 +93,12 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	# Initialize Objective Function Expression
 	@expression(EP, eObj, 0)
 
-
 	#@expression(EP, :eCO2Cap[cap=1:inputs["NCO2Cap"]], 0)
 	@expression(EP, eGenerationByZone[z=1:Z, t=1:T], 0)
+	
+	# Initialize energy losses related to technologies
+	@expression(EP, eELOSSByZone[z=1:Z], 0)
+
 	# Initialize Capacity Reserve Margin Expression
 	if setup["CapacityReserveMargin"] > 0
 		@expression(EP, eCapResMarBalance[res=1:inputs["NCapacityReserveMargin"], t=1:T], 0)

--- a/src/model/resources/storage/storage_all.jl
+++ b/src/model/resources/storage/storage_all.jl
@@ -93,10 +93,9 @@ function storage_all!(EP::Model, inputs::Dict, setup::Dict)
 			[y in STOR_ALL, t=1:T], EP[:vP][y,t] <= EP[:vS][y, hoursbefore(hours_per_subperiod,t,1)]*dfGen[y,:Eff_Down]
 		end)
 	end
-	#From co2 Policy module
-	@expression(EP, eELOSSByZone[z=1:Z],
-		sum(EP[:eELOSS][y] for y in intersect(STOR_ALL, dfGen[dfGen[!,:Zone].==z,:R_ID]))
-	)
+	# From co2 Policy module
+	expr = @expression(EP, [z=1:Z], sum(EP[:eELOSS][y] for y in intersect(STOR_ALL, dfGen[dfGen[!,:Zone].==z,:R_ID])))
+	EP[:eELOSSByZone] += expr
 end
 
 function storage_all_reserves!(EP::Model, inputs::Dict)


### PR DESCRIPTION
## Description
This closes #541. 
The expression `eELOSSByZone` is accessed in `co2_cap.jl` without being initialized if no storage is present in the model. 

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [X] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. 
- [X] Code has been tested to ensure all functionality works as intended.
- [X] CHANGELOG.md has been updated.
- [X] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested
Run `Example_Systems/SmallNewEngland/OneZone/Run.j`. 

## Post-approval checklist for GenX core developers
After the PR is approved

- [ ] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [ ] Remember to squash and merge if incorporating into develop