### PR TITLE
Separate reserves into creation and constraints

### DIFF
--- a/src/model/core/reserves.jl
+++ b/src/model/core/reserves.jl
@@ -217,6 +217,13 @@ function reserves_core!(EP::Model, inputs::Dict, setup::Dict)
 
 	REG = inputs["REG"]
 	RSV = inputs["RSV"]
+    STOR_ALL = inputs["STOR_ALL"]
+
+    pDemand = inputs["pD"]
+    pP_Max(y, t) = inputs["pP_Max"][y, t]
+
+    systemwide_hourly_demand = sum(pDemand, dims=2)
+    must_run_vre_generation(t) = sum(pP_Max(y, t) * EP[:eTotalCap][y] for y in intersect(inputs["VRE"], inputs["MUST_RUN"]))
 
 	### Variables ###
 
@@ -228,10 +235,10 @@ function reserves_core!(EP::Model, inputs::Dict, setup::Dict)
 
 	# Storage techs have two pairs of auxilary variables to reflect contributions to regulation and reserves
 	# when charging and discharging (primary variable becomes equal to sum of these auxilary variables)
-	@variable(EP, vREG_discharge[y in intersect(inputs["STOR_ALL"], REG), t=1:T] >= 0) # Contribution to regulation (primary reserves) (mirrored variable used for storage devices)
-	@variable(EP, vRSV_discharge[y in intersect(inputs["STOR_ALL"], RSV), t=1:T] >= 0) # Contribution to operating reserves (secondary reserves) (mirrored variable used for storage devices)
-	@variable(EP, vREG_charge[y in intersect(inputs["STOR_ALL"], REG), t=1:T] >= 0) # Contribution to regulation (primary reserves) (mirrored variable used for storage devices)
-	@variable(EP, vRSV_charge[y in intersect(inputs["STOR_ALL"], RSV), t=1:T] >= 0) # Contribution to operating reserves (secondary reserves) (mirrored variable used for storage devices)
+	@variable(EP, vREG_discharge[y in intersect(STOR_ALL, REG), t=1:T] >= 0) # Contribution to regulation (primary reserves) (mirrored variable used for storage devices)
+	@variable(EP, vRSV_discharge[y in intersect(STOR_ALL, RSV), t=1:T] >= 0) # Contribution to operating reserves (secondary reserves) (mirrored variable used for storage devices)
+	@variable(EP, vREG_charge[y in intersect(STOR_ALL, REG), t=1:T] >= 0) # Contribution to regulation (primary reserves) (mirrored variable used for storage devices)
+	@variable(EP, vRSV_charge[y in intersect(STOR_ALL, RSV), t=1:T] >= 0) # Contribution to operating reserves (secondary reserves) (mirrored variable used for storage devices)
 
 	@variable(EP, vUNMET_RSV[t=1:T] >= 0) # Unmet operating reserves penalty/cost
 
@@ -239,16 +246,16 @@ function reserves_core!(EP::Model, inputs::Dict, setup::Dict)
 	## Total system reserve expressions
 	# Regulation requirements as a percentage of demand and scheduled variable renewable energy production in each hour
 	# Reg up and down requirements are symmetric
-	@expression(EP, eRegReq[t=1:T], inputs["pReg_Req_Demand"]*sum(inputs["pD"][t,z] for z=1:Z) +
-		inputs["pReg_Req_VRE"]*sum(inputs["pP_Max"][y,t]*EP[:eTotalCap][y] for y in intersect(inputs["VRE"], inputs["MUST_RUN"])))
+    @expression(EP, eRegReq[t=1:T], inputs["pReg_Req_Demand"] * systemwide_hourly_demand[t] +
+                inputs["pReg_Req_VRE"] * must_run_vre_generation(t))
 	# Operating reserve up / contingency reserve requirements as ˚a percentage of demand and scheduled variable renewable energy production in each hour
 	# and the largest single contingency (generator or transmission line outage)
-	@expression(EP, eRsvReq[t=1:T], inputs["pRsv_Req_Demand"]*sum(inputs["pD"][t,z] for z=1:Z) +
-				inputs["pRsv_Req_VRE"]*sum(inputs["pP_Max"][y,t]*EP[:eTotalCap][y] for y in intersect(inputs["VRE"], inputs["MUST_RUN"])))
+    @expression(EP, eRsvReq[t=1:T], inputs["pRsv_Req_Demand"] * systemwide_hourly_demand[t] +
+                inputs["pRsv_Req_VRE"] * must_run_vre_generation(t))
 
 	# N-1 contingency requirement is considered only if Unit Commitment is being modeled
 	if UCommit >= 1 && (inputs["pDynamic_Contingency"] >= 1 || inputs["pStatic_Contingency"] > 0)
-		EP[:eRsvReq] = EP[:eRsvReq] + EP[:eContingencyReq]
+        add_to_expression!(EP[:eRsvReq], EP[:eContingencyReq])
 	end
 
 	## Objective Function Expressions ##

--- a/src/model/core/reserves.jl
+++ b/src/model/core/reserves.jl
@@ -223,7 +223,7 @@ function reserves_core!(EP::Model, inputs::Dict, setup::Dict)
     pP_Max(y, t) = inputs["pP_Max"][y, t]
 
     systemwide_hourly_demand = sum(pDemand, dims=2)
-    must_run_vre_generation(t) = sum(pP_Max(y, t) * EP[:eTotalCap][y] for y in intersect(inputs["VRE"], inputs["MUST_RUN"]))
+    must_run_vre_generation(t) = sum(pP_Max(y, t) * EP[:eTotalCap][y] for y in intersect(inputs["VRE"], inputs["MUST_RUN"]); init=0)
 
 	### Variables ###
 

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -94,10 +94,10 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	EP[:eObj] = AffExpr(0.0)
 
 	create_empty_expression!(EP, :eGenerationByZone, (Z, T))
-	
+
 	# Energy losses related to technologies
 	create_empty_expression!(EP, :eELOSSByZone, Z)
-	
+
 	# Initialize Capacity Reserve Margin Expression
 	if setup["CapacityReserveMargin"] > 0
 		create_empty_expression!(EP, :eCapResMarBalance, (inputs["NCapacityReserveMargin"], T))
@@ -190,6 +190,10 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	end
 
 	# Policies
+
+	if setup["Reserves"] > 0
+		reserves_constraints!(EP, inputs)
+	end
 
 	# CO2 emissions limits
 	if setup["CO2Cap"] > 0


### PR DESCRIPTION
Divide the core Reserves functionality into

1. variable and expression creation

(space for potential modification)

2. constraint application

This makes the module more like the CapacityReserveMargin or MinCapReq policies, allowing the expressions to be modified before constraints are applied.