### PR TITLE
Fix DimensionMismatch error in refactored CRM

### DIFF
--- a/src/write_outputs/capacity_reserve_margin/write_capacity_value.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_capacity_value.jl
@@ -48,7 +48,7 @@ function write_capacity_value(path::AbstractString, inputs::Dict, setup::Dict, E
 
         power(y::Vector{Int}) = value.(EP[:vP][y, riskyhour])'
 
-        capvalue[riskyhour, THERM_ALL_EX] = crm_derate(i, THERM_ALL_EX)
+        capvalue[riskyhour, THERM_ALL_EX] .= crm_derate(i, THERM_ALL_EX)
 
         capvalue[riskyhour, VRE_EX] = crm_derate(i, VRE_EX) .* max_power(riskyhour, VRE_EX)
 


### PR DESCRIPTION
This fixed a bug where cases multiple CRM zones have an error during output.

This has been tested now; the results are identical (except for -0.0 vs 0.0, like before.)