### PR TITLE
Prefer columns-style network format to matrix format

### DIFF
--- a/Example_Systems/RealSystemExample/ISONE_Trizone/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
-NENGREST,z1,1,1,-1,0,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
-NENG_CT,z2,2,1,0,-1,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-NENG_ME,z3,,,,,,,,,,,,,
+,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
+NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
+NENG_ME,z3,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
 NENG_ME,z3,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
-NENGREST,z1,1,1,-1,0,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
-NENG_CT,z2,2,1,0,-1,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-NENG_ME,z3,,,,,,,,,,,,,
+,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
+NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
+NENG_ME,z3,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Network.csv
@@ -1,4 +1,4 @@
 ,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-NENG_ME,z3,,,,,,,,,,,
+NENG_ME,z3,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_FullTimeseries/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
 NENG_ME,z3,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p1/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p1/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
 NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
 NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
 NENG_ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p1/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p1/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-NENGREST,z1,1,1,-1,0,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
-NENG_CT,z2,2,1,0,-1,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
-NENG_ME,z3,,,,,,,,,,,,,,,,
+,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
+NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
+NENG_ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p2/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p2/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
 NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
 NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
 NENG_ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p2/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p2/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-NENGREST,z1,1,1,-1,0,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
-NENG_CT,z2,2,1,0,-1,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
-NENG_ME,z3,,,,,,,,,,,,,,,,
+,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
+NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
+NENG_ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p3/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p3/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
 NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
 NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
 NENG_ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p3/Network.csv
+++ b/Example_Systems/RealSystemExample/ISONE_Trizone_MultiStage/Inputs/Inputs_p3/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-NENGREST,z1,1,1,-1,0,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
-NENG_CT,z2,2,1,0,-1,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
-NENG_ME,z3,,,,,,,,,,,,,,,,
+,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0,5900,0.062,30
+NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0,4000,0.062,30
+NENG_ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Network.csv
+++ b/Example_Systems/RealSystemExample/MGA_ISONE_Trizone_FullTimeseries/Network.csv
@@ -1,4 +1,4 @@
-,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
-NENGREST,z1,1,1,-1,0,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
-NENG_CT,z2,2,1,0,-1,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-NENG_ME,z3,,,,,,,,,,,,,
+,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+NENGREST,z1,1,1,2,2950,NENGREST_to_NENG_CT,123.0584,0.012305837,2950,12060,0.95,0,0
+NENG_CT,z2,2,1,3,2000,NENGREST_to_NENG_ME,196.5385,0.019653847,2000,19261,0.95,0,0
+NENG_ME,z3,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+﻿,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
 ME,z3,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-ME,z3,,,,,,,,,,,,,
+﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
+CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
+ME,z3,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p1/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p1/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
-ME,z3,,,,,,,,,,,,,,,,
+﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
+CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
+ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p1/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p1/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+﻿,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
 ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p2/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p2/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
-ME,z3,,,,,,,,,,,,,,,,
+﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
+CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
+ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p2/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p2/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+﻿,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
 ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p3/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p3/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
-ME,z3,,,,,,,,,,,,,,,,
+﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
+CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
+ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p3/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_MultiStage/Inputs/Inputs_p3/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
+﻿,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1,Line_Max_Flow_Possible_MW,WACC,Capital_Recovery_Period
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0,7000,0.062,30
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0,5000,0.062,30
 ME,z3,,,,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_Slack_Variables_Example/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_Slack_Variables_Example/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+﻿,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
 ME,z3,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_Slack_Variables_Example/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_Slack_Variables_Example/Network.csv
@@ -1,4 +1,4 @@
 ﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-ME,z3,,,,,,,,,,,
+ME,z3,,,,,,,,,,,,

--- a/Example_Systems/SmallNewEngland/ThreeZones_Slack_Variables_Example/Network.csv
+++ b/Example_Systems/SmallNewEngland/ThreeZones_Slack_Variables_Example/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-ME,z3,,,,,,,,,,,,,
+﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
+CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
+ME,z3,,,,,,,,,,,

--- a/Example_Systems/VREStor_Example/Network.csv
+++ b/Example_Systems/VREStor_Example/Network.csv
@@ -1,4 +1,4 @@
-Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
+Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
 z1,1.0,1,2,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
 z2,2.0,1,3,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
 z3,,,,,,,,,,,,,,,,

--- a/Example_Systems/VREStor_Example/Network.csv
+++ b/Example_Systems/VREStor_Example/Network.csv
@@ -1,4 +1,4 @@
 Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
 z1,1.0,1,2,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
 z2,2.0,1,3,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
-z3,,,,,,,,,,,,,,,,,
+z3,,,,,,,,,,,,,,,,

--- a/Example_Systems/VREStor_Example/Network.csv
+++ b/Example_Systems/VREStor_Example/Network.csv
@@ -1,4 +1,4 @@
-Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
-z1,1.0,1.0,-1.0,0.0,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
-z2,2.0,1.0,0.0,-1.0,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
+Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
+z1,1.0,1,2,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
+z2,2.0,1,3,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
 z3,,,,,,,,,,,,,,,,,

--- a/docs/src/data_documentation.md
+++ b/docs/src/data_documentation.md
@@ -188,7 +188,7 @@ This input file contains input parameters related to: 1) definition of model zon
 |**Settings-specific Columns**|
 |**Multiple zone model**||
 |Network\_Lines | Numerical index for each network line. The length of this column is counted but the actual values are not used.|
-| z* (Network map) **OR** Start_Node, End_Node | See below |
+| z* (Network map) **OR** Start_Zone, End_Zone | See below |
 |Line\_Max\_Flow\_MW | Existing capacity of the inter-regional transmission line.|
 |**NetworkExpansion = 1**||
 |Line\_Max\_Reinforcement\_MW |Maximum allowable capacity addition to the existing transmission line.|
@@ -211,10 +211,10 @@ This input file contains input parameters related to: 1) definition of model zon
 There are two interfaces implemented for specifying the network topology itself: a matrix interface and a list interface.
 Only one choice is permitted in a given file.
 
-The list interface consists of a column for the lines start node and one for the line's end node.
+The list interface consists of a column for the lines start zone and one for the line's end zone.
 Here is a snippet of the Network.csv file for a map with three zones and two lines:
 ```
-Network_Lines, Start_Node, End_Node,
+Network_Lines, Start_Zone, End_Zone,
             1,          1,        2,
             2,          1,        3,
 ```
@@ -229,8 +229,8 @@ Network_Lines, z1, z2, z3,
             2,  1,  0, -1,
 ```
 
-Note that in either case, positive flows indicate flow from start to end node;
-negative flows indicate flow from end to start node.
+Note that in either case, positive flows indicate flow from start to end zone;
+negative flows indicate flow from end to start zone.
 
 
 #### 2.1.3 Demand\_data.csv (Load\_data.csv)

--- a/docs/src/data_documentation.md
+++ b/docs/src/data_documentation.md
@@ -188,7 +188,7 @@ This input file contains input parameters related to: 1) definition of model zon
 |**Settings-specific Columns**|
 |**Multiple zone model**||
 |Network\_Lines | Numerical index for each network line. The length of this column is counted but the actual values are not used.|
-| z* (Network map) **OR** Origin_Zone, Destination_Zone | See below |
+| z* (Network map) **OR** Start_Node, End_Node | See below |
 |Line\_Max\_Flow\_MW | Existing capacity of the inter-regional transmission line.|
 |**NetworkExpansion = 1**||
 |Line\_Max\_Reinforcement\_MW |Maximum allowable capacity addition to the existing transmission line.|
@@ -211,17 +211,17 @@ This input file contains input parameters related to: 1) definition of model zon
 There are two interfaces implemented for specifying the network topology itself: a matrix interface and a list interface.
 Only one choice is permitted in a given file.
 
-The list interface consists of a column for the lines origin zone and one for the line's destination zone.
+The list interface consists of a column for the lines start node and one for the line's end node.
 Here is a snippet of the Network.csv file for a map with three zones and two lines:
 ```
-Network_Lines, Origin_Zone, Destination_Zone,
-            1,           1,                2,
-            2,           1,                3,
+Network_Lines, Start_Node, End_Node,
+            1,          1,        2,
+            2,          1,        3,
 ```
 
 The matrix interface requires N columns labeled `z1, z2, z3 ... zN`,
-and L rows, one for each network line (or interregional path), with a `1` in the column corresponding to the 'origin' zone 
-and a `-1` in the column corresponding to the 'destination' zone for each line.
+and L rows, one for each network line (or interregional path), with a `1` in the column corresponding to the 'start' zone 
+and a `-1` in the column corresponding to the 'end' zone for each line.
 Here is the same network map implemented as a matrix:
 ```
 Network_Lines, z1, z2, z3,
@@ -229,8 +229,8 @@ Network_Lines, z1, z2, z3,
             2,  1,  0, -1,
 ```
 
-Note that in either case, positive flows indicate flow from origin to destination zone;
-negative flows indicate flow from destination to origin zone.
+Note that in either case, positive flows indicate flow from start to end node;
+negative flows indicate flow from end to start node.
 
 
 #### 2.1.3 Demand\_data.csv (Load\_data.csv)

--- a/docs/src/model_notation.md
+++ b/docs/src/model_notation.md
@@ -238,7 +238,7 @@ $\mathcal{W} \subseteq \mathcal{G}$ | where $\mathcal{W}$ set of hydroelectric g
 |$\rho_{y,z,t}^{max,pv}$ | Maximum available generation per unit of installed capacity for the solar PV component of a co-located VRE and storage resource during time step t for technology y in zone z [%]|
 |$\rho_{y,z,t}^{max,wind}$ | Maximum available generation per unit of installed capacity for the wind component of a co-located VRE and storage resource during time step t for technology y in zone z [%]|
 |$VREIndex_{y,z}$ | Resource bin index for VRE technology $y$ in zone $z$. $VREIndex_{y,z}=1$ for the first bin, and $VREIndex_{y,z}=0$ for remaining bins. Only defined for $y\in \mathcal{VRE}$ |
-|$\varphi^{map}_{l,z}$ | Topology of the network, for line l: $\varphi^{map}_{l,z}=1$ for start node $z$, - 1 for end node $z$, 0 otherwise. |
+|$\varphi^{map}_{l,z}$ | Topology of the network, for line l: $\varphi^{map}_{l,z}=1$ for start zone $z$, - 1 for end zone $z$, 0 otherwise. |
 |$\eta_{y,z}^{loss}$ | Self discharge rate per time step per unit of installed capacity for storage technology $y$ in zone $z$ [%]|
 |$\eta_{y,z}^{charge}$ | Single-trip efficiency of storage charging/demand deferral for technology $y$ in zone $z$ [%]|
 |$\eta_{y,z}^{discharge}$ | Single-trip efficiency of storage (and hydro reservoir) discharging/demand satisfaction for technology $y$ in zone $z$ [%]|

--- a/docs/src/model_notation.md
+++ b/docs/src/model_notation.md
@@ -238,7 +238,7 @@ $\mathcal{W} \subseteq \mathcal{G}$ | where $\mathcal{W}$ set of hydroelectric g
 |$\rho_{y,z,t}^{max,pv}$ | Maximum available generation per unit of installed capacity for the solar PV component of a co-located VRE and storage resource during time step t for technology y in zone z [%]|
 |$\rho_{y,z,t}^{max,wind}$ | Maximum available generation per unit of installed capacity for the wind component of a co-located VRE and storage resource during time step t for technology y in zone z [%]|
 |$VREIndex_{y,z}$ | Resource bin index for VRE technology $y$ in zone $z$. $VREIndex_{y,z}=1$ for the first bin, and $VREIndex_{y,z}=0$ for remaining bins. Only defined for $y\in \mathcal{VRE}$ |
-|$\varphi^{map}_{l,z}$ | Topology of the network, for line l: $\varphi^{map}_{l,z}=1$ for zone $z$ of origin, - 1 for zone $z$ of destination, 0 otherwise. |
+|$\varphi^{map}_{l,z}$ | Topology of the network, for line l: $\varphi^{map}_{l,z}=1$ for start node $z$, - 1 for end node $z$, 0 otherwise. |
 |$\eta_{y,z}^{loss}$ | Self discharge rate per time step per unit of installed capacity for storage technology $y$ in zone $z$ [%]|
 |$\eta_{y,z}^{charge}$ | Single-trip efficiency of storage charging/demand deferral for technology $y$ in zone $z$ [%]|
 |$\eta_{y,z}^{discharge}$ | Single-trip efficiency of storage (and hydro reservoir) discharging/demand satisfaction for technology $y$ in zone $z$ [%]|

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -90,19 +90,19 @@ end
 
 Loads the network map from a list-style interface
 ```
-..., Network_Lines, Origin_Zone, Destination_Zone, ...
-                 1,           1,                2,
-                 2,           1,                3,
+..., Network_Lines, Start_Node, End_Node, ...
+                 1,           1,       2,
+                 2,           1,       3,
 ```
 """
 function load_network_map_from_list(network_var::DataFrame, Z, L, list_columns)
     start_col, end_col = list_columns
     mat = zeros(L, Z)
-    start_zones = collect(skipmissing(network_var[!, start_col]))
-    end_zones = collect(skipmissing(network_var[!, end_col]))
+    start_nodes = collect(skipmissing(network_var[!, start_col]))
+    end_nodes = collect(skipmissing(network_var[!, end_col]))
     for l in 1:L
-        mat[l, start_zones[l]] = 1
-        mat[l, end_zones[l]] = -1
+        mat[l, start_nodes[l]] = 1
+        mat[l, end_nodes[l]] = -1
     end
     mat
 end
@@ -128,7 +128,7 @@ end
 function load_network_map(network_var::DataFrame, Z, L)
     columns = names(network_var)
 
-    list_columns = ["Origin_Zone", "Destination_Zone"]
+    list_columns = ["Start_Node", "End_Node"]
     has_network_list = all([c in columns for c in list_columns])
 
     zones_as_strings = ["z" * string(i) for i in 1:Z]
@@ -145,6 +145,8 @@ function load_network_map(network_var::DataFrame, Z, L)
     elseif has_network_list
         load_network_map_from_list(network_var, Z, L, list_columns)
     elseif has_network_matrix
+		@warn """Loading the network map in a matrix format is deprecated as of v0.4
+		and will be removed in v0.5."""
         load_network_map_from_matrix(network_var, Z, L)
     end
 end

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -90,7 +90,7 @@ end
 
 Loads the network map from a list-style interface
 ```
-..., Network_Lines, Start_Node, End_Node, ...
+..., Network_Lines, Start_Zone, End_Zone, ...
                  1,           1,       2,
                  2,           1,       3,
 ```
@@ -98,11 +98,11 @@ Loads the network map from a list-style interface
 function load_network_map_from_list(network_var::DataFrame, Z, L, list_columns)
     start_col, end_col = list_columns
     mat = zeros(L, Z)
-    start_nodes = collect(skipmissing(network_var[!, start_col]))
-    end_nodes = collect(skipmissing(network_var[!, end_col]))
+    start_zones = collect(skipmissing(network_var[!, start_col]))
+    end_zones = collect(skipmissing(network_var[!, end_col]))
     for l in 1:L
-        mat[l, start_nodes[l]] = 1
-        mat[l, end_nodes[l]] = -1
+        mat[l, start_zones[l]] = 1
+        mat[l, end_zones[l]] = -1
     end
     mat
 end
@@ -117,7 +117,7 @@ Loads the network map from a matrix-style interface
                  2,  1,  0, -1,
 ```
 This is equivalent to the list-style interface where the zone zN with entry +1 is the
-starting node of the line and the zone with entry -1 is the ending node of the line.
+starting zone of the line and the zone with entry -1 is the ending zone of the line.
 """
 function load_network_map_from_matrix(network_var::DataFrame, Z, L)
     # Topology of the network source-sink matrix
@@ -129,14 +129,14 @@ end
 function load_network_map(network_var::DataFrame, Z, L)
     columns = names(network_var)
 
-    list_columns = ["Start_Node", "End_Node"]
+    list_columns = ["Start_Zone", "End_Zone"]
     has_network_list = all([c in columns for c in list_columns])
 
     zones_as_strings = ["z" * string(i) for i in 1:Z]
     has_network_matrix =  all([c in columns for c in zones_as_strings])
 
     instructions = """The transmission network should be specified in the form of a matrix
-           (with columns z1, z2, ... zN) or in the form of lists (with Start_Node, End_Node),
+           (with columns z1, z2, ... zN) or in the form of lists (with Start_Zone, End_Zone),
            but not both. See the documentation for examples."""
 
     if has_network_list && has_network_matrix
@@ -154,7 +154,7 @@ function network_map_matrix_format_deprecation_warning()
 		@warn """Specifying the network map as a matrix is deprecated as of v0.4
 and will be removed in v0.5. Instead, use the more compact list-style format.
 
-..., Network_Lines, Start_Node, End_Node, ...
+..., Network_Lines, Start_Zone, End_Zone, ...
                  1,          1,        2,
                  2,          1,        3,
                  3,          2,        3,

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -121,6 +121,7 @@ starting node of the line and the zone with entry -1 is the ending node of the l
 """
 function load_network_map_from_matrix(network_var::DataFrame, Z, L)
     # Topology of the network source-sink matrix
+	network_map_matrix_format_deprecation_warning()
     col = findall(s -> s == "z1", names(network_var))[1]
     mat = Matrix{Float64}(network_var[1:L, col:col+Z-1])
 end
@@ -145,8 +146,17 @@ function load_network_map(network_var::DataFrame, Z, L)
     elseif has_network_list
         load_network_map_from_list(network_var, Z, L, list_columns)
     elseif has_network_matrix
-		@warn """Loading the network map in a matrix format is deprecated as of v0.4
-		and will be removed in v0.5."""
         load_network_map_from_matrix(network_var, Z, L)
     end
+end
+
+function network_map_matrix_format_deprecation_warning()
+		@warn """Loading the network map in a matrix format is deprecated as of v0.4
+and will be removed in v0.5. Instead, use the more compact list-style format.
+
+..., Network_Lines, Start_Node, End_Node, ...
+                 1,          1,        2,
+                 2,          1,        3,
+                 3,          2,        3,
+""" maxlog=1
 end

--- a/src/load_inputs/load_network_data.jl
+++ b/src/load_inputs/load_network_data.jl
@@ -151,7 +151,7 @@ function load_network_map(network_var::DataFrame, Z, L)
 end
 
 function network_map_matrix_format_deprecation_warning()
-		@warn """Loading the network map in a matrix format is deprecated as of v0.4
+		@warn """Specifying the network map as a matrix is deprecated as of v0.4
 and will be removed in v0.5. Instead, use the more compact list-style format.
 
 ..., Network_Lines, Start_Node, End_Node, ...

--- a/test/ThreeZones/Network.csv
+++ b/test/ThreeZones/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+﻿,Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
 MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
 CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
 ME,z3,,,,,,,,,,,,

--- a/test/ThreeZones/Network.csv
+++ b/test/ThreeZones/Network.csv
@@ -1,4 +1,4 @@
-﻿,Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
-MA,z1,1,1,-1,0,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
-CT,z2,2,1,0,-1,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
-ME,z3,,,,,,,,,,,,,
+﻿,Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,transmission_path_name,distance_mile,Line_Loss_Percentage,Line_Max_Reinforcement_MW,Line_Reinforcement_Cost_per_MWyr,DerateCapRes_1,CapRes_1,CapRes_Excl_1
+MA,z1,1,1,2,2950,MA_to_CT,123.0584,0.012305837,2950,12060,0.95,0,0
+CT,z2,2,1,3,2000,MA_to_ME,196.5385,0.019653847,2000,19261,0.95,0,0
+ME,z3,,,,,,,,,,,,

--- a/test/VREStor/Network.csv
+++ b/test/VREStor/Network.csv
@@ -1,4 +1,4 @@
-Network_zones,Network_Lines,z1,z2,z3,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
-z1,1.0,1.0,-1.0,0.0,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
-z2,2.0,1.0,0.0,-1.0,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
-z3,,,,,,,,,,,,,,,,,
+Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
+z1,1.0,1,2,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
+z2,2.0,1,3,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
+z3,,,,,,,,,,,,,,,,

--- a/test/VREStor/Network.csv
+++ b/test/VREStor/Network.csv
@@ -1,4 +1,4 @@
-Network_zones,Network_Lines,Start_Node,End_Node,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
+Network_zones,Network_Lines,Start_Zone,End_Zone,Line_Max_Flow_MW,Line_Min_Flow_MW,transmission_path_name,Line_Reinforcement_Cost_per_MWyr,Line_Reinforcement_Cost_per_MW,Line_Loss_Percentage,Line_Max_Reinforcement_MW,DerateCapRes_1,CapRes_Excl_1,DerateCapRes_2,CapRes_Excl_2,DerateCapRes_3,CapRes_Excl_3
 z1,1.0,1,2,820.0,820.0,EIC_to_TRE,45958.0,948772.0,0.0649,410.0,0.95,0.0,0.95,0.0,0.95,0.0
 z2,2.0,1,3,1830.0,1830.0,EIC_to_WECC,71600.0,1478140.0,0.1001,915.0,0.95,0.0,0.95,0.0,0.95,0.0
 z3,,,,,,,,,,,,,,,,


### PR DESCRIPTION
This changes the preferred Network input format from a matrix of 1, 0, -1 to lists of Start_Node, End_Node.

* This may not be perfect: here we use Node, which a more technical term, but in other places in the code and docs we largely use "Zone".