### PR TITLE
use maxlog=1

### DIFF
--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -46,7 +46,7 @@ function validate_settings!(settings::Dict{Any,Any})
         @warn """The behavior of the TimeDomainReduction and OperationWrapping
         settings have changed recently. OperationWrapping has been removed,
         and is ignored. The relevant behavior is now controlled by TimeDomainReduction.
-        Please see the Methods page in the documentation."""
+        Please see the Methods page in the documentation.""" maxlog=1
     end
 
 end

--- a/src/load_inputs/load_generators_data.jl
+++ b/src/load_inputs/load_generators_data.jl
@@ -645,7 +645,7 @@ While for now, New_Build entries of {1, 0, -1} are still supported,
 this format is being deprecated.
 Now and going forward, New_Build and Can_Retire should be separate columns,
 each with values {0, 1}.
-Please see the documentation for additional details."
+Please see the documentation for additional details." maxlog=1
 end
 
 function resources_which_can_be_retired(df::DataFrame)::Set{Int64}


### PR DESCRIPTION
Prevent double printing of warnings.