### PR TITLE
Correctly write and scale unmet reserve output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for anyone running non-myopic multistage GenX with asymmetric storage.
 - Fix computation of cumulative minimum capacity retirements in multistage GenX (#514)
 - Fix access of eELOSSByZone expr before initialization (#541)
+- Correctly write unmet reserves (in reg_dn.csv) (#575)
+- Correctly scale total reserves column (in reg_dn.csv) (#594)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/src/write_outputs/reserves/write_rsv.jl
+++ b/src/write_outputs/reserves/write_rsv.jl
@@ -8,11 +8,11 @@ function write_rsv(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfRsv = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone])
 	rsv = zeros(G,T)
 	unmet_vec = zeros(T)
-	rsv[RSV, :] = value.(EP[:vRSV][RSV, :])
-	unmet_vec[RSV] = value.(EP[:vUNMET_RSV][RSV])
-	total_unmet = (sum(unmet_vec)*scale_factor)
-	dfRsv.AnnualSum = (rsv*scale_factor) * inputs["omega"]
-	dfRsv = hcat(dfRsv, DataFrame((rsv*scale_factor), :auto))
+	rsv[RSV, :] = value.(EP[:vRSV][RSV, :]) * scale_factor
+	unmet_vec = value.(EP[:vUNMET_RSV]) * scale_factor
+	total_unmet = sum(unmet_vec)
+	dfRsv.AnnualSum = rsv * inputs["omega"]
+	dfRsv = hcat(dfRsv, DataFrame(rsv, :auto))
 	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualSum");[Symbol("t$t") for t in 1:T]]
 	rename!(dfRsv,auxNew_Names)
 


### PR DESCRIPTION
This fixes #575.

* This also fixes the scale of the outputs in the Total column.
* This was tested on the SmallNewEngland/ThreeZones case and it fixes the unmet reserves column and correctly scales the Total column.