### PR TITLE
Use scale_factor in write_min/max_capacity_requirement.jl

### DIFF
--- a/src/write_outputs/min_max_capacity_requirement/write_maximum_capacity_requirement.jl
+++ b/src/write_outputs/min_max_capacity_requirement/write_maximum_capacity_requirement.jl
@@ -3,9 +3,6 @@ function write_maximum_capacity_requirement(path::AbstractString, inputs::Dict, 
     dfMaxCapPrice = DataFrame(Constraint = [Symbol("MaxCapReq_$maxcap") for maxcap = 1:NumberOfMaxCapReqs],
                                 Price=-dual.(EP[:cZoneMaxCapReq]))
 
-    # Generally the scale_factor is used to convert
-    # GW (in the model) back to MW (for output)
-    # and likewise for $M to $.
     scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
 
     dfMaxCapPrice.Price *= scale_factor

--- a/src/write_outputs/min_max_capacity_requirement/write_minimum_capacity_requirement.jl
+++ b/src/write_outputs/min_max_capacity_requirement/write_minimum_capacity_requirement.jl
@@ -8,10 +8,10 @@ function write_minimum_capacity_requirement(path::AbstractString, inputs::Dict, 
     dfMinCapPrice.Price *= scale_factor # Convert Million $/GW to $/MW
 
     if haskey(inputs, "MinCapPriceCap")
-		dfMinCapPrice[!,:Slack] = convert(Array{Float64}, value.(EP[:vMinCap_slack]))
-		dfMinCapPrice[!,:Penalty] = convert(Array{Float64}, value.(EP[:eCMinCap_slack]))
+        dfMinCapPrice[!,:Slack] = convert(Array{Float64}, value.(EP[:vMinCap_slack]))
+        dfMinCapPrice[!,:Penalty] = convert(Array{Float64}, value.(EP[:eCMinCap_slack]))
         dfMinCapPrice.Slack *= scale_factor # Convert GW to MW
         dfMinCapPrice.Penalty *= scale_factor^2 # Convert Million $ to $
-	end
+    end
     CSV.write(joinpath(path, "MinCapReq_prices_and_penalties.csv"), dfMinCapPrice)
 end


### PR DESCRIPTION
## Description

This makes the code write_min_capacity and write_max_capacity symmetrical. This is a minor step toward separating the 'currency scale' and 'energy scale'.

## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Code Refactor
- [ ] Performance Improvements

## Checklist

- [n/a] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [n/a] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

Tested on RealSystemExample/ISONE_Trizone after creating a MaxCapReq entry. The results are bit-for-bit identical.

## Post-approval checklist for GenX core developers
After the PR is approved

- [ ] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [ ] Remember to squash and merge if incorporating into develop
