### PR TITLE
Add validation MUST_RUN reserve contribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix access of eELOSSByZone expr before initialization (#541)
 - Correctly write unmet reserves (in reg_dn.csv) (#575)
 - Correctly scale total reserves column (in reg_dn.csv) (#594)
+- Add validation for `Reg_Max` and `Rsv_Max` columns in `Generators_data.csv` when `MUST_RUN` is set to 1 (#576)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/test/resource_test.jl
+++ b/test/resource_test.jl
@@ -65,23 +65,71 @@ let
                      :STOR => 0,
                      :LDS => 1)
 
+    # MUST_RUN units contribution to reserves
+    must_run = Resource(:Resource => "must_run",
+                        :THERM => 0,
+                        :FLEX => 0,
+                        :HYDRO => 0,
+                        :VRE => 0,
+                        :MUST_RUN => 1,
+                        :STOR => 0,
+                        :LDS => 0,
+                        :Reg_Max => 0,
+                        :Rsv_Max => 0)
+    bad_must_run = Resource(:Resource => "bad_must_run",
+                            :THERM => 0,
+                            :FLEX => 0,
+                            :HYDRO => 0,
+                            :VRE => 0,
+                            :MUST_RUN => 1,
+                            :STOR => 0,
+                            :LDS => 0,
+                            :Reg_Max => 0.083333333,
+                            :Rsv_Max => 0.166666667)
+    bad_mustrun_reg = Resource(:Resource => "bad_mustrun_reg",
+                            :THERM => 0,
+                            :FLEX => 0,
+                            :HYDRO => 0,
+                            :VRE => 0,
+                            :MUST_RUN => 1,
+                            :STOR => 0,
+                            :LDS => 0,
+                            :Reg_Max => 0.083333333,
+                            :Rsv_Max => 0)
+    bad_mustrun_rsv = Resource(:Resource => "bad_mustrun_rsv",
+                            :THERM => 0,
+                            :FLEX => 0,
+                            :HYDRO => 0,
+                            :VRE => 0,
+                            :MUST_RUN => 1,
+                            :STOR => 0,
+                            :LDS => 0,
+                            :Reg_Max => 0,
+                            :Rsv_Max => 0.166666667)
+
     function check_okay(resource)
         e = check_resource(resource)
+        println(e)
         @test length(e) == 0
     end
 
     function check_bad(resource)
         e = check_resource(resource)
+        println(e)
         @test length(e) > 0
     end
 
     check_okay(therm)
     check_okay(stor_lds)
     check_okay(hydro_lds)
+    check_okay(must_run)
 
     check_bad(bad_lds)
     check_bad(bad_none)
     check_bad(bad_twotypes)
+    check_bad(bad_must_run)
+    check_bad(bad_mustrun_reg)
+    check_bad(bad_mustrun_rsv)
 
     multiple_resources = [therm, stor_lds, hydro_lds]
     check_okay(multiple_resources)


### PR DESCRIPTION
This PR adds a validation check that MUST_RUN units have Reg_Max and Rsv_Max set to zero in `Generators_data.csv`. Fixes #576. 