### PR TITLE
Fix scaling of tx losses in tlosses.csv #616

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly write unmet reserves (in reg_dn.csv) (#575)
 - Correctly scale total reserves column (in reg_dn.csv) (#594)
 - Add validation for `Reg_Max` and `Rsv_Max` columns in `Generators_data.csv` when `MUST_RUN` is set to 1 (#576)
+- Fix scaling of transmission losses in write_transmission_losses.jl (#621)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/src/write_outputs/transmission/write_transmission_losses.jl
+++ b/src/write_outputs/transmission/write_transmission_losses.jl
@@ -7,7 +7,7 @@ function write_transmission_losses(path::AbstractString, inputs::Dict, setup::Di
 	tlosses = zeros(L, T)
 	tlosses[LOSS_LINES, :] = value.(EP[:vTLOSS][LOSS_LINES, :])
 	if setup["ParameterScale"] == 1
-	    tlosses[LOSS_LINES, :] *= ModelScalingFactor^2
+	    tlosses[LOSS_LINES, :] *= ModelScalingFactor
 	end
 	dfTLosses.AnnualSum = tlosses * inputs["omega"]
 	dfTLosses = hcat(dfTLosses, DataFrame(tlosses, :auto))


### PR DESCRIPTION
This PR fixes #616.
Transmission losses due to power flows are now scaled only once.