### PR TITLE
Fix scaling of tx losses in tlosses.csv #616

### DIFF
--- a/src/write_outputs/transmission/write_transmission_losses.jl
+++ b/src/write_outputs/transmission/write_transmission_losses.jl
@@ -7,7 +7,7 @@ function write_transmission_losses(path::AbstractString, inputs::Dict, setup::Di
 	tlosses = zeros(L, T)
 	tlosses[LOSS_LINES, :] = value.(EP[:vTLOSS][LOSS_LINES, :])
 	if setup["ParameterScale"] == 1
-	    tlosses[LOSS_LINES, :] *= ModelScalingFactor^2
+	    tlosses[LOSS_LINES, :] *= ModelScalingFactor
 	end
 	dfTLosses.AnnualSum = tlosses * inputs["omega"]
 	dfTLosses = hcat(dfTLosses, DataFrame(tlosses, :auto))


### PR DESCRIPTION
This PR fixes the scaling of the transmission losses due to power flows in write_transmission_losses.jl (#616)