### PR TITLE
Added computation of cumulative minimum capacity retirements in multistage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix summation error when a set of hours is empty (in thermal_commit.jl).
 - Fix access to eELOSSByZone expr before initialization (#541)
 - Fix modeling of hydro reservoir with long duration storage (#572).
+- Fix computation of cumulative minimum capacity retirements in multistage GenX (#514)
 
 ### Changed
 

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -130,6 +130,8 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict)
         inputs_dict[t] = load_inputs(mysetup, inpath_sub)
         inputs_dict[t] = configure_multi_stage_inputs(inputs_dict[t],mysetup["MultiStageSettingsDict"],mysetup["NetworkExpansion"])
 
+        compute_cumulative_min_retirements!(inputs_dict,t)
+        
         # Step 2) Generate model
         model_dict[t] = generate_model(mysetup, inputs_dict[t], OPTIMIZER)
     end


### PR DESCRIPTION
Fixed computation of cumulative minimum retirements in multistage code. Previously, minimum capacity retirement parameters were not added up and this resulted in the minimum retirement constraints enforcing wrong lower bounds