### PR TITLE
Fix update of starting transmission capacity in multistage GenX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix access to eELOSSByZone expr before initialization (#541)
 - Fix modeling of hydro reservoir with long duration storage (#572).
 - Fix computation of cumulative minimum capacity retirements in multistage GenX (#514)
+- Fix update of starting transmission capacity in multistage GenX
 
 ### Changed
 

--- a/src/multi_stage/dual_dynamic_programming.jl
+++ b/src/multi_stage/dual_dynamic_programming.jl
@@ -294,11 +294,14 @@ function fix_initial_investments(EP_prev::Model, EP_cur::Model, start_cap_d::Dic
     # and the associated linking constraint name (c) as a value
     for (e, c) in start_cap_d
         for y in keys(EP_cur[c])
-	    if y[1] in RET_CAP # extract resource integer index value from key
-                # Set the right hand side value of the linking initial capacity constraint in the current
-                # stage to the value of the available capacity variable solved for in the previous stages
-                set_normalized_rhs(EP_cur[c][y], value(EP_prev[e][y]))
-            end
+                # Set the right hand side value of the linking initial capacity constraint in the current stage to the value of the available capacity variable solved for in the previous stages
+                if c == :cExistingTransCap
+                    set_normalized_rhs(EP_cur[c][y], value(EP_prev[e][y]))
+                else
+	                if y[1] in RET_CAP # extract resource integer index value from key
+                        set_normalized_rhs(EP_cur[c][y], value(EP_prev[e][y]))
+                    end
+                end
         end
     end
     return EP_cur


### PR DESCRIPTION
Fixing bug in function `fix_initial_investments`, introduced by #326 . The aim of this PR was to set the initial capacity at stage t using the available capacity in stage t-1 only for generators whose indices are in RET_CAP. 

However, `fix_initial_investments` does not consider only generators, but also transmission lines. So if the index of a given transmission line does not happen to be in RET_CAP, the available capacity of that transmission line at stage t-1 will not be carried over to stage t.

As a result of this bug, GenX believes that it has not built any transmission capacity in previous stages for those lines whose indices are not in RET_CAP, and so in every stage after the first one GenX will build a lot more transmission capacity than it should. 