### PR TITLE
Add a setting to turn off storage virtual discharge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add functions to compute conflicting constraints when model is infeasible if supported by the solver (#624).
 - New settings parameter, VirtualChargeDischargeCost to test script and VREStor example case. The PR 608 attempts to 
   introduce this parameter as cost of virtual charging and discharging to avoid unusual results (#608). 
+- New settings parameter, StorageVirtualDischarge, to turn storage virtual charging and discharging off if desired by the user (#638).
 
 
 ### Fixed

--- a/docs/src/data_documentation.md
+++ b/docs/src/data_documentation.md
@@ -73,6 +73,9 @@ Note that all settings parameters are case sensitive.
 | WriteOutputs | Flag for writing the model outputs with hourly resolution or just the annual sum.|
 || "full" = write the model outputs with hourly resolution.|
 || "annual" = write only the annual sum of the model outputs.|
+|StorageVirtualDischarge| Flag for whether to include the ability for storage to have a "virtual" charge and discharge that contributes to the capacity reserve margin.
+||1 (default) = include virtual charging and discharging||
+||0 = do not include virtual charging and discharging||
 
 Additionally, Solver related settings parameters are specified in the appropriate .yml file (e.g. `gurobi_settings.yml` or `cplex_settings.yml`),
 which should be located in the current working directory.

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -29,6 +29,7 @@ function default_settings()
         "WriteOutputs" => "full",
         "ComputeConflicts" => 0,
         "ResourcePath" => "Resources",
+        "StorageVirtualDischarge" => 1,
     )
 end
 

--- a/src/model/resources/vre_stor/vre_stor.jl
+++ b/src/model/resources/vre_stor/vre_stor.jl
@@ -1901,6 +1901,7 @@ function vre_stor_capres!(EP::Model, inputs::Dict, setup::Dict)
     rep_periods = inputs["REP_PERIOD"]
 
     virtual_discharge_cost = inputs["VirtualChargeDischargeCost"]
+    StorageVirtualDischarge = setup["StorageVirtualDischarge"]
     
     by_rid(rid, sym) = by_rid_res(rid, sym, gen_VRE_STOR)
     
@@ -2032,10 +2033,18 @@ function vre_stor_capres!(EP::Model, inputs::Dict, setup::Dict)
     @expression(EP, eCapResMarBalanceStor_VRE_STOR[res=1:inputs["NCapacityReserveMargin"], t=1:T],(
         sum(derating_factor(gen[y],tag=res)*by_rid(y,:etainverter)*inputs["pP_Max_Solar"][y,t]*EP[:eTotalCap_SOLAR][y] for y in inputs["VS_SOLAR"])
         + sum(derating_factor(gen[y],tag=res)*inputs["pP_Max_Wind"][y,t]*EP[:eTotalCap_WIND][y] for y in inputs["VS_WIND"])
-        + sum(derating_factor(gen[y],tag=res)*by_rid(y,:etainverter)*(EP[:vP_DC_DISCHARGE][y,t]+vCAPRES_DC_DISCHARGE[y,t]) for y in DC_DISCHARGE)
-        + sum(derating_factor(gen[y],tag=res)*(EP[:vP_AC_DISCHARGE][y,t]+vCAPRES_AC_DISCHARGE[y,t]) for y in AC_DISCHARGE)
-        - sum(derating_factor(gen[y],tag=res)*(EP[:vP_DC_CHARGE][y,t]+vCAPRES_DC_CHARGE[y,t])/by_rid(y,:etainverter) for y in DC_CHARGE)
-        - sum(derating_factor(gen[y],tag=res)*(EP[:vP_AC_CHARGE][y,t]+vCAPRES_AC_CHARGE[y,t]) for y in AC_CHARGE)))
+        + sum(derating_factor(gen[y],tag=res)*by_rid(y,:etainverter)*(EP[:vP_DC_DISCHARGE][y,t]) for y in DC_DISCHARGE)
+        + sum(derating_factor(gen[y],tag=res)*(EP[:vP_AC_DISCHARGE][y,t]) for y in AC_DISCHARGE)
+        - sum(derating_factor(gen[y],tag=res)*(EP[:vP_DC_CHARGE][y,t])/by_rid(y,:etainverter) for y in DC_CHARGE)
+        - sum(derating_factor(gen[y],tag=res)*(EP[:vP_AC_CHARGE][y,t]) for y in AC_CHARGE)))
+    if StorageVirtualDischarge > 0
+        @expression(EP, eCapResMarBalanceStor_VRE_STOR_Virtual[res=1:inputs["NCapacityReserveMargin"], t=1:T],(
+        sum(derating_factor(gen[y],tag=res)*by_rid(y,:etainverter)*(vCAPRES_DC_DISCHARGE[y,t]) for y in DC_DISCHARGE)
+        + sum(derating_factor(gen[y],tag=res)*(vCAPRES_AC_DISCHARGE[y,t]) for y in AC_DISCHARGE)
+        - sum(derating_factor(gen[y],tag=res)*(vCAPRES_DC_CHARGE[y,t])/by_rid(y,:etainverter) for y in DC_CHARGE)
+        - sum(derating_factor(gen[y],tag=res)*(vCAPRES_AC_CHARGE[y,t]) for y in AC_CHARGE)))
+        add_similar_to_expression!(eCapResMarBalanceStor_VRE_STOR,eCapResMarBalanceStor_VRE_STOR_Virtual)
+    end
     EP[:eCapResMarBalance] += EP[:eCapResMarBalanceStor_VRE_STOR]
 
     ### OBJECTIVE FUNCTION ADDITIONS ###


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

This section should include a detailed description of the motivation for the PR,
and a description of why it was implemented in the way that it was,
to the extent that these things are applicable.
-->

This PR adds a setting and accompanying feature to turn off the storage virtual charge/discharge functionality if desired by the user.

Note that this PR does not remove the decision variables for virtual charging and discharging; it only removes them from the CRM constraint itself, so they are forced to zero by the optimization as they have an associated cost. I designed this PR this way for the sake of code simplicity, as this is a feature that is not expected to be used regularly (so I don't think that the increased computational efficiency that would come from removing the variables from the optimization entirely is worth the increased code complexity).

## What type of PR is this? (check all applicable)

- [x] Feature

## Related Tickets & Documents
<!-- 
Please use this format to link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

<!--
If applicable: What cases should we try before/after? Will this alter any outputs, or is it a strictly internal change?
-->

I also did this myself, but if you run the SmallNewEngland case with the new "StorageVirtualDischarge" setting set to 0, you will see that the storage virtual charging and discharging in virtual_discharge.csv becomes all zeros. 

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  After the PR is approved we will give you a chance to tidy up the branch before merging.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. In the case of large feature or module additions, it is best to work towards a "minimum viable product" that is thoroughly tested but may not have all desired functionality or features, make a PR for this, and then later work to add more features.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.

-->

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
