### PR TITLE
Fix write_status with UCommit=1 and Shadow Prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cost assignment to virtual storage charge/discharge - issue #604 (#608)
 - Fix modeling of hydro reservoir with long duration storage (#572).
 - Fix update of starting transmission capacity in multistage GenX
+- Fix write_status with UCommit = WriteShadowPrices = 1 (#645)
 
 ### Changed
 - Use add_to_expression! instead of the += and -= operators for memory performance improvements (#498).

--- a/src/model/solve_model.jl
+++ b/src/model/solve_model.jl
@@ -70,14 +70,6 @@ function solve_model(EP::Model, setup::Dict)
 			println("MILP solved for primal")
 		end
 
-		if !has_duals(EP) && setup["WriteShadowPrices"] == 1
-			# function to fix integers and linearize problem
-			fix_integers(EP)
-			# re-solve statement for LP solution
-			println("Solving LP solution for duals")
-			optimize!(EP)
-		end
-
 		## Record solver time
 		solver_time = time() - solver_start_time
 	elseif setup["ComputeConflicts"]==0

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -47,6 +47,16 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
 	
 	output_settings_d["WriteStatus"] && write_status(path, inputs, setup, EP)
 
+	# linearize and re-solve model if duals are not available but ShadowPrices are requested
+	if !has_duals(EP) && setup["WriteShadowPrices"] == 1
+		# function to fix integers and linearize problem
+		fix_integers(EP)
+		# re-solve statement for LP solution
+		println("Solving LP solution for duals")
+		set_silent(EP)
+		optimize!(EP)
+	end
+
 	if output_settings_d["WriteCosts"]
 		elapsed_time_costs = @elapsed write_costs(path, inputs, setup, EP)
 		println("Time elapsed for writing costs is")


### PR DESCRIPTION
`write_status` looks for the `objective_bound` of the model, which might not exist (for example, HiGHS only implements the objective bound for MIPs).

This fix addresses the issue with `write_outputs` when `UCommit = WriteShadowPrices = 1` by moving the linearization and re-optimization of the model immediately after `write_status` is called.
