### PR TITLE
Fix ret_cap_charge in load_resources

### DIFF
--- a/src/load_inputs/load_resources_data.jl
+++ b/src/load_inputs/load_resources_data.jl
@@ -1008,7 +1008,7 @@ function add_resources_to_input_data!(inputs::Dict, setup::Dict, case_path::Abst
 		# Set of asymmetric charge/discharge storage resources eligible for new charge capacity
         new_cap_charge = intersect(buildable, ids_with(gen, max_charge_cap_mw), inputs["STOR_ASYMMETRIC"])
 		# Set of asymmetric charge/discharge storage resources eligible for charge capacity retirements
-        ret_cap_charge = intersect(buildable, ids_with_nonneg(gen, existing_charge_cap_mw), inputs["STOR_ASYMMETRIC"])
+        ret_cap_charge = intersect(retirable, ids_with_nonneg(gen, existing_charge_cap_mw), inputs["STOR_ASYMMETRIC"])
 	end
 	inputs["NEW_CAP_CHARGE"] = new_cap_charge
 	inputs["RET_CAP_CHARGE"] = ret_cap_charge


### PR DESCRIPTION
This fixes the set `ret_cap_charge` (or `inputs["RET_CAP_CHARGE"]`), which consists of the indices of resources with `Can_Retire = 1` and `existing_charge_cap_mw >= 0`