### PR TITLE
Improve `@expressions` performance by pre processing sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default option, `"EnableJuMPDirectMode"`, to build the model more efficiently.
 Models running with, non-default, solvers Cbc and Clp will fail unless
 `"EnableJuMPDirectMode"` is set to false (#835).
+- Improve `@expressions` performance by pre-processing sets (#815).
 
 ## [0.4.4] - 2025-02-04
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.4-dev.4"
+version = "0.4.4-dev.5"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/model/core/co2.jl
+++ b/src/model/core/co2.jl
@@ -134,7 +134,10 @@ function co2!(EP::Model, inputs::Dict)
     end
 
     # emissions by zone
+    RESOURCES_BY_ZONE = map(1:Z) do z
+        return resources_in_zone_by_rid(gen, z)
+    end
     @expression(EP, eEmissionsByZone[z = 1:Z, t = 1:T],
-        sum(eEmissionsByPlant[y, t] for y in resources_in_zone_by_rid(gen, z)))
+        sum(eEmissionsByPlant[y, t] for y in RESOURCES_BY_ZONE[z]))
     return EP
 end

--- a/src/model/core/discharge/investment_discharge.jl
+++ b/src/model/core/discharge/investment_discharge.jl
@@ -69,34 +69,39 @@ function investment_discharge!(EP::Model, inputs::Dict, setup::Dict)
         @expression(EP, eExistingCap[y in 1:G], existing_cap_mw(gen[y]))
     end
 
+    NEW_RET_RETROFIT_CAP = intersect(NEW_CAP, RET_CAP, RETROFIT_CAP) # Resources eligible for new capacity, retirements and being retrofitted
+    RET_ONLY_CAP = intersect(setdiff(RET_CAP, NEW_CAP), setdiff(RET_CAP, RETROFIT_CAP)) # Resources eligible for only capacity retirements
+    RET_NEW_CAP = setdiff(intersect(RET_CAP, NEW_CAP), RETROFIT_CAP) # Resources eligible for retirement and new capacity
+    RET_RETROFIT_CAP = setdiff(intersect(RET_CAP, RETROFIT_CAP), NEW_CAP) # Resources eligible for retirement and retrofitting
+    NEW_ONLY_CAP = intersect(setdiff(NEW_CAP, RET_CAP), setdiff(NEW_CAP, RETROFIT_CAP))  # Resources eligible for only new capacity
     @expression(EP, eTotalCap[y in 1:G],
-        if y in intersect(NEW_CAP, RET_CAP, RETROFIT_CAP) # Resources eligible for new capacity, retirements and being retrofitted
+        if y in NEW_RET_RETROFIT_CAP
             if y in COMMIT
                 eExistingCap[y] +
                 cap_size(gen[y]) * (EP[:vCAP][y] - EP[:vRETCAP][y] - EP[:vRETROFITCAP][y])
             else
                 eExistingCap[y] + EP[:vCAP][y] - EP[:vRETCAP][y] - EP[:vRETROFITCAP][y]
             end
-        elseif y in intersect(setdiff(RET_CAP, NEW_CAP), setdiff(RET_CAP, RETROFIT_CAP)) # Resources eligible for only capacity retirements
+        elseif y in RET_ONLY_CAP
             if y in COMMIT
                 eExistingCap[y] - cap_size(gen[y]) * EP[:vRETCAP][y]
             else
                 eExistingCap[y] - EP[:vRETCAP][y]
             end
-        elseif y in setdiff(intersect(RET_CAP, NEW_CAP), RETROFIT_CAP) # Resources eligible for retirement and new capacity
+        elseif y in RET_NEW_CAP
             if y in COMMIT
                 eExistingCap[y] + cap_size(gen[y]) * (EP[:vCAP][y] - EP[:vRETCAP][y])
             else
                 eExistingCap[y] + EP[:vCAP][y] - EP[:vRETCAP][y]
             end
-        elseif y in setdiff(intersect(RET_CAP, RETROFIT_CAP), NEW_CAP) # Resources eligible for retirement and retrofitting
+        elseif y in RET_RETROFIT_CAP
             if y in COMMIT
                 eExistingCap[y] -
                 cap_size(gen[y]) * (EP[:vRETROFITCAP][y] + EP[:vRETCAP][y])
             else
                 eExistingCap[y] - (EP[:vRETROFITCAP][y] + EP[:vRETCAP][y])
             end
-        elseif y in intersect(setdiff(NEW_CAP, RET_CAP), setdiff(NEW_CAP, RETROFIT_CAP))  # Resources eligible for only new capacity
+        elseif y in NEW_ONLY_CAP
             if y in COMMIT
                 eExistingCap[y] + cap_size(gen[y]) * EP[:vCAP][y]
             else

--- a/src/model/core/fuel.jl
+++ b/src/model/core/fuel.jl
@@ -96,6 +96,10 @@ function fuel!(EP::Model, inputs::Dict, setup::Dict)
     SINGLE_FUEL = inputs["SINGLE_FUEL"]
     ALLAM_CYCLE_LOX = inputs["ALLAM_CYCLE_LOX"]
 
+    RESOURCES_BY_ZONE = map(1:Z) do z
+        return resources_in_zone_by_rid(gen, z)
+    end
+
     fuels = inputs["fuels"]
     fuel_costs = inputs["fuel_costs"]
     omega = inputs["omega"]
@@ -195,7 +199,7 @@ function fuel!(EP::Model, inputs::Dict, setup::Dict)
         sum(omega[t] * EP[:eCFuelStart][y, t] for t in 1:T))
     # zonal level total fuel cost for output
     @expression(EP, eZonalCFuelStart[z = 1:Z],
-        sum(EP[:ePlantCFuelStart][y] for y in resources_in_zone_by_rid(gen, z)))
+        sum(EP[:ePlantCFuelStart][y] for y in RESOURCES_BY_ZONE[z]))
 
     # Fuel cost for power generation
     # for multi-fuel resources
@@ -219,7 +223,7 @@ function fuel!(EP::Model, inputs::Dict, setup::Dict)
         sum(omega[t] * EP[:eCFuelOut][y, t] for t in 1:T))
     # zonal level total fuel cost for output
     @expression(EP, eZonalCFuelOut[z = 1:Z],
-        sum(EP[:ePlantCFuelOut][y] for y in resources_in_zone_by_rid(gen, z)))
+        sum(EP[:ePlantCFuelOut][y] for y in RESOURCES_BY_ZONE[z]))
 
     # system level total fuel cost for output
     @expression(EP, eTotalCFuelOut, sum(eZonalCFuelOut[z] for z in 1:Z))

--- a/src/model/core/fuel.jl
+++ b/src/model/core/fuel.jl
@@ -238,9 +238,12 @@ function fuel!(EP::Model, inputs::Dict, setup::Dict)
                 MULTI_FUELS)))
     end
 
+    RESOURCES_BY_SINGLE_FUEL = map(1:NUM_FUEL) do f
+        return intersect(setdiff(resources_with_fuel(gen, fuels[f]), ALLAM_CYCLE_LOX), SINGLE_FUEL)
+    end
     @expression(EP, eFuelConsumption_single[f in 1:NUM_FUEL, t in 1:T],
         sum(EP[:vFuel][y, t] + EP[:eStartFuel][y, t]
-        for y in intersect(setdiff(resources_with_fuel(gen, fuels[f]), ALLAM_CYCLE_LOX), SINGLE_FUEL)))
+        for y in RESOURCES_BY_SINGLE_FUEL[f]))
 
     @expression(EP, eFuelConsumption[f in 1:NUM_FUEL, t in 1:T],
         if !isempty(MULTI_FUELS)

--- a/src/model/resources/curtailable_variable_renewable/curtailable_variable_renewable.jl
+++ b/src/model/resources/curtailable_variable_renewable/curtailable_variable_renewable.jl
@@ -37,8 +37,9 @@ function curtailable_variable_renewable!(EP::Model, inputs::Dict, setup::Dict)
 
     ## Power Balance Expressions ##
 
+    VRE_BY_ZONE = [intersect(VRE, resources_in_zone_by_rid(gen, z)) for z in 1:Z]
     @expression(EP, ePowerBalanceDisp[t = 1:T, z = 1:Z],
-        sum(EP[:vP][y, t] for y in intersect(VRE, resources_in_zone_by_rid(gen, z))))
+        sum(EP[:vP][y, t] for y in VRE_BY_ZONE[z]))
     add_similar_to_expression!(EP[:ePowerBalance], EP[:ePowerBalanceDisp])
 
     # Capacity Reserves Margin policy
@@ -80,10 +81,9 @@ function curtailable_variable_renewable!(EP::Model, inputs::Dict, setup::Dict)
         fix.(EP[:vP][y, :], 0.0, force = true)
     end
     ##CO2 Polcy Module VRE Generation by zone
-    @expression(EP, eGenerationByVRE[z = 1:Z, t = 1:T], # the unit is GW
-        sum(EP[:vP][y, t]
-        for y in intersect(inputs["VRE"], resources_in_zone_by_rid(gen, z))))
-    add_similar_to_expression!(EP[:eGenerationByZone], eGenerationByVRE)
+    # We use the transpose here because eGenerationByZone is [1:Z, 1:T] and
+    # ePowerBalanceDisp is [1:T, 1:Z].
+    add_similar_to_expression!(EP[:eGenerationByZone], ePowerBalanceDisp')
 end
 
 @doc raw"""

--- a/src/model/resources/flexible_demand/flexible_demand.jl
+++ b/src/model/resources/flexible_demand/flexible_demand.jl
@@ -65,9 +65,12 @@ function flexible_demand!(EP::Model, inputs::Dict, setup::Dict)
     ### Expressions ###
 
     ## Power Balance Expressions ##
+    FLEX_BY_ZONE = map(1:Z) do z
+        return intersect(FLEX, resources_in_zone_by_rid(gen, z))
+    end
     @expression(EP, ePowerBalanceDemandFlex[t = 1:T, z = 1:Z],
         sum(-EP[:vP][y, t] + EP[:vCHARGE_FLEX][y, t]
-        for y in intersect(FLEX, resources_in_zone_by_rid(gen, z))))
+        for y in FLEX_BY_ZONE[z]))
     add_similar_to_expression!(EP[:ePowerBalance], ePowerBalanceDemandFlex)
 
     # Capacity Reserves Margin policy

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -103,8 +103,11 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
     ### Expressions ###
 
     ## Power Balance Expressions ##
+    HYDRO_RES_BY_ZONE = map(1:Z) do z
+        return intersect(HYDRO_RES, resources_in_zone_by_rid(gen, z))
+    end
     @expression(EP, ePowerBalanceHydroRes[t = 1:T, z = 1:Z],
-        sum(EP[:vP][y, t] for y in intersect(HYDRO_RES, resources_in_zone_by_rid(gen, z))))
+        sum(EP[:vP][y, t] for y in HYDRO_RES_BY_ZONE[z]))
     add_similar_to_expression!(EP[:ePowerBalance], ePowerBalanceHydroRes)
 
     # Capacity Reserves Margin policy
@@ -180,7 +183,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
     end
     ##CO2 Polcy Module Hydro Res Generation by zone
     @expression(EP, eGenerationByHydroRes[z = 1:Z, t = 1:T], # the unit is GW
-        sum(EP[:vP][y, t] for y in intersect(HYDRO_RES, resources_in_zone_by_rid(gen, z))))
+        sum(EP[:vP][y, t] for y in HYDRO_RES_BY_ZONE[z]))
     add_similar_to_expression!(EP[:eGenerationByZone], eGenerationByHydroRes)
 end
 

--- a/src/model/resources/hydrogen/electrolyzer.jl
+++ b/src/model/resources/hydrogen/electrolyzer.jl
@@ -152,9 +152,12 @@ function electrolyzer!(EP::Model, inputs::Dict, setup::Dict)
     # from within the same zone as the electrolyzers are located to be >= hourly consumption from electrolyzers in the zone
     # (and any charging by qualified storage within the zone used to help increase electrolyzer utilization).
     if setup["HydrogenHourlyMatching"] == 1 && setup["HourlyMatching"] == 1
+        ELECTROLYZERS_BY_ZONE = map(1:Z) do z
+            return intersect(ELECTROLYZERS, resources_in_zone_by_rid(gen, z))
+        end
         @expression(EP, eHMElectrolyzer[t in 1:T, z in 1:Z],
             -sum(EP[:vUSE][y, t]
-            for y in intersect(resources_in_zone_by_rid(gen, z), ELECTROLYZERS)))
+            for y in ELECTROLYZERS_BY_ZONE[z]))
         add_similar_to_expression!(EP[:eHM], eHMElectrolyzer)
     end
 

--- a/src/model/resources/hydrogen/electrolyzer.jl
+++ b/src/model/resources/hydrogen/electrolyzer.jl
@@ -85,7 +85,7 @@ function electrolyzer!(EP::Model, inputs::Dict, setup::Dict)
     ### Expressions ###
 
     ## Power Balance Expressions ##
-    ELECTROLYZERS_BY_ZONE = map(HYDROGEN_ZONES) do z
+    ELECTROLYZERS_BY_ZONE = map(1:Z) do z
         return intersect(ELECTROLYZERS, resources_in_zone_by_rid(gen, z))
     end
     @expression(EP, ePowerBalanceElectrolyzers[t in 1:T, z in 1:Z],

--- a/src/model/resources/must_run/must_run.jl
+++ b/src/model/resources/must_run/must_run.jl
@@ -27,9 +27,11 @@ function must_run!(EP::Model, inputs::Dict, setup::Dict)
     ### Expressions ###
 
     ## Power Balance Expressions ##
-
+    MUST_RUN_BY_ZONE = map(1:Z) do z
+        return intersect(MUST_RUN, resources_in_zone_by_rid(gen, z))
+    end
     @expression(EP, ePowerBalanceNdisp[t = 1:T, z = 1:Z],
-        sum(EP[:vP][y, t] for y in intersect(MUST_RUN, resources_in_zone_by_rid(gen, z))))
+        sum(EP[:vP][y, t] for y in MUST_RUN_BY_ZONE[z]))
     add_similar_to_expression!(EP[:ePowerBalance], ePowerBalanceNdisp)
 
     # Capacity Reserves Margin policy
@@ -50,6 +52,6 @@ function must_run!(EP::Model, inputs::Dict, setup::Dict)
         EP[:vP][y, t]==inputs["pP_Max"][y, t] * EP[:eTotalCap][y])
     ##CO2 Polcy Module Must Run Generation by zone
     @expression(EP, eGenerationByMustRun[z = 1:Z, t = 1:T], # the unit is GW
-        sum(EP[:vP][y, t] for y in intersect(MUST_RUN, resources_in_zone_by_rid(gen, z))))
+        sum(EP[:vP][y, t] for y in MUST_RUN_BY_ZONE[z]))
     add_similar_to_expression!(EP[:eGenerationByZone], eGenerationByMustRun)
 end

--- a/src/model/resources/storage/investment_charge.jl
+++ b/src/model/resources/storage/investment_charge.jl
@@ -74,12 +74,15 @@ function investment_charge!(EP::Model, inputs::Dict, setup::Dict)
             existing_charge_cap_mw(gen[y]))
     end
 
+    NEW_AND_RET_CAP_CHARGE = intersect(NEW_CAP_CHARGE, RET_CAP_CHARGE)
+    NEW_NOT_RET_CAP_CHARGE = setdiff(NEW_CAP_CHARGE, RET_CAP_CHARGE)
+    RET_NOT_NEW_CAP_CHARGE = setdiff(RET_CAP_CHARGE, NEW_CAP_CHARGE)
     @expression(EP, eTotalCapCharge[y in STOR_ASYMMETRIC],
-        if (y in intersect(NEW_CAP_CHARGE, RET_CAP_CHARGE))
+        if (y in NEW_AND_RET_CAP_CHARGE)
             eExistingCapCharge[y] + vCAPCHARGE[y] - vRETCAPCHARGE[y]
-        elseif (y in setdiff(NEW_CAP_CHARGE, RET_CAP_CHARGE))
+        elseif (y in NEW_NOT_RET_CAP_CHARGE)
             eExistingCapCharge[y] + vCAPCHARGE[y]
-        elseif (y in setdiff(RET_CAP_CHARGE, NEW_CAP_CHARGE))
+        elseif (y in RET_NOT_NEW_CAP_CHARGE)
             eExistingCapCharge[y] - vRETCAPCHARGE[y]
         else
             eExistingCapCharge[y]

--- a/src/model/resources/storage/investment_energy.jl
+++ b/src/model/resources/storage/investment_energy.jl
@@ -75,12 +75,15 @@ function investment_energy!(EP::Model, inputs::Dict, setup::Dict)
         @expression(EP, eExistingCapEnergy[y in STOR_ALL], existing_cap_mwh(gen[y]))
     end
 
+    NEW_AND_RET_CAP_ENERGY = intersect(NEW_CAP_ENERGY, RET_CAP_ENERGY)
+    NEW_NOT_RET_CAP_ENERGY = setdiff(NEW_CAP_ENERGY, RET_CAP_ENERGY)
+    RET_NOT_NEW_CAP_ENERGY = setdiff(RET_CAP_ENERGY, NEW_CAP_ENERGY)
     @expression(EP, eTotalCapEnergy[y in STOR_ALL],
-        if (y in intersect(NEW_CAP_ENERGY, RET_CAP_ENERGY))
+        if (y in NEW_AND_RET_CAP_ENERGY)
             eExistingCapEnergy[y] + vCAPENERGY[y] - vRETCAPENERGY[y]
-        elseif (y in setdiff(NEW_CAP_ENERGY, RET_CAP_ENERGY))
+        elseif (y in NEW_NOT_RET_CAP_ENERGY)
             eExistingCapEnergy[y] + vCAPENERGY[y]
-        elseif (y in setdiff(RET_CAP_ENERGY, NEW_CAP_ENERGY))
+        elseif (y in RET_NOT_NEW_CAP_ENERGY)
             eExistingCapEnergy[y] - vRETCAPENERGY[y]
         else
             eExistingCapEnergy[y]

--- a/src/model/resources/thermal/thermal.jl
+++ b/src/model/resources/thermal/thermal.jl
@@ -24,9 +24,12 @@ function thermal!(EP::Model, inputs::Dict, setup::Dict)
         thermal_no_commit!(EP, inputs, setup)
     end
     ##CO2 Polcy Module Thermal Generation by zone
+    THERM_ALL_BY_ZONE = map(1:Z) do z
+        return intersect(inputs["THERM_ALL"], resources_in_zone_by_rid(gen, z))
+    end
     @expression(EP, eGenerationByThermAll[z = 1:Z, t = 1:T], # the unit is GW
         sum(EP[:vP][y, t]
-        for y in intersect(inputs["THERM_ALL"], resources_in_zone_by_rid(gen, z))))
+        for y in THERM_ALL_BY_ZONE[z]))
     add_similar_to_expression!(EP[:eGenerationByZone], eGenerationByThermAll)
 
     # Capacity Reserves Margin policy

--- a/src/model/resources/thermal/thermal.jl
+++ b/src/model/resources/thermal/thermal.jl
@@ -25,7 +25,7 @@ function thermal!(EP::Model, inputs::Dict, setup::Dict)
     end
     ##CO2 Polcy Module Thermal Generation by zone
     THERM_ALL_BY_ZONE = map(1:Z) do z
-        return intersect(inputs["THERM_ALL"], resources_in_zone_by_rid(gen, z))
+        return intersect(THERM_ALL, resources_in_zone_by_rid(gen, z))
     end
     @expression(EP, eGenerationByThermAll[z = 1:Z, t = 1:T], # the unit is GW
         sum(EP[:vP][y, t]

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -153,9 +153,12 @@ function thermal_commit!(EP::Model, inputs::Dict, setup::Dict)
     end
 
     ## Power Balance Expressions ##
+    THERM_COMMIT_BY_ZONE = map(1:Z) do z
+        return intersect(THERM_COMMIT, resources_in_zone_by_rid(gen, z))
+    end
     @expression(EP, ePowerBalanceThermCommit[t = 1:T, z = 1:Z],
         sum(EP[:vP][y, t]
-        for y in intersect(THERM_COMMIT, resources_in_zone_by_rid(gen, z))))
+        for y in THERM_COMMIT_BY_ZONE[z]))
     add_similar_to_expression!(EP[:ePowerBalance], ePowerBalanceThermCommit)
 
     ### Constraints ###

--- a/src/model/resources/thermal/thermal_no_commit.jl
+++ b/src/model/resources/thermal/thermal_no_commit.jl
@@ -56,9 +56,12 @@ function thermal_no_commit!(EP::Model, inputs::Dict, setup::Dict)
     ### Expressions ###
 
     ## Power Balance Expressions ##
+    THERM_NO_COMMIT_BY_ZONE = map(1:Z) do z
+        return intersect(THERM_NO_COMMIT, resources_in_zone_by_rid(gen, z))
+    end
     @expression(EP, ePowerBalanceThermNoCommit[t = 1:T, z = 1:Z],
         sum(EP[:vP][y, t]
-        for y in intersect(THERM_NO_COMMIT, resources_in_zone_by_rid(gen, z))))
+        for y in THERM_NO_COMMIT_BY_ZONE[z]))
     add_similar_to_expression!(EP[:ePowerBalance], ePowerBalanceThermNoCommit)
 
     ### Constraints ###

--- a/src/model/resources/vre_stor/vre_stor.jl
+++ b/src/model/resources/vre_stor/vre_stor.jl
@@ -1253,7 +1253,7 @@ function stor_vre_stor!(EP::Model, inputs::Dict, setup::Dict)
     for z in 1:Z, t in 1:T
         if !isempty(gen_VRE_STOR_BY_ZONE_AND_STOR[z])
             EP[:ePowerBalance_VRE_STOR][t, z] -= sum(vCHARGE_VRE_STOR[y, t]
-            for y in igen_VRE_STOR_BY_ZONE_AND_STOR[z])
+            for y in gen_VRE_STOR_BY_ZONE_AND_STOR[z])
         end
     end
 

--- a/src/write_outputs/write_power_balance.jl
+++ b/src/write_outputs/write_power_balance.jl
@@ -36,22 +36,22 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
     for z in 1:Z
         POWER_ZONE = intersect(resources_in_zone_by_rid(gen, z),
             union(THERM_ALL, VRE, MUST_RUN, HYDRO_RES, ALLAM_CYCLE_LOX))
-        if isempty(intersect(resources_in_zone_by_rid(gen, z), ALLAM_CYCLE_LOX))
+        ALLAM_ZONE = intersect(resources_in_zone_by_rid(gen, z), ALLAM_CYCLE_LOX)
+        if isempty(ALLAM_ZONE)
             powerbalance[(z - 1) * L + 1, :] = sum(value.(EP[:vP][POWER_ZONE, :]), dims = 1)
         else
-            ALLAM_ZONE = intersect(resources_in_zone_by_rid(gen, z), ALLAM_CYCLE_LOX)
             powerbalance[(z - 1) * L + 1, :] = sum(value.(Array(EP[:vP][POWER_ZONE, :])), dims = 1) - sum(value.(Array(EP[:vCHARGE_ALLAM][ALLAM_ZONE, :])), dims = 1)
         end
-        if !isempty(intersect(resources_in_zone_by_rid(gen, z), STOR_ALL))
-            STOR_ALL_ZONE = intersect(resources_in_zone_by_rid(gen, z), STOR_ALL)
+        STOR_ALL_ZONE = intersect(resources_in_zone_by_rid(gen, z), STOR_ALL)
+        if !isempty(STOR_ALL_ZONE)
             powerbalance[(z - 1) * L + 2, :] = sum(value.(EP[:vP][STOR_ALL_ZONE, :]),
                 dims = 1)
             powerbalance[(z - 1) * L + 3, :] = (-1) * sum(
                 (value.(EP[:vCHARGE][STOR_ALL_ZONE,:]).data),
                 dims = 1)
         end
-        if !isempty(intersect(resources_in_zone_by_rid(gen, z), FLEX))
-            FLEX_ZONE = intersect(resources_in_zone_by_rid(gen, z), FLEX)
+        FLEX_ZONE = intersect(resources_in_zone_by_rid(gen, z), FLEX)
+        if !isempty(FLEX_ZONE)
             powerbalance[(z - 1) * L + 4, :] = sum(
                 (value.(EP[:vCHARGE_FLEX][FLEX_ZONE,:]).data),
                 dims = 1)


### PR DESCRIPTION
## Description

This PR replaces #773 the improvement is the better performance in constructing JuMP `@expression`s.

This new PR only contains the set pre-processing from #773, so it is easier to review.

These set operations are performed more frequently than necessary. Pre-processing the sets before building expressions is more efficient as it requires strictly less work and allocations.

## What type of PR is this? (check all applicable)

- [x] Performance Improvements

## Related Tickets & Documents

Replaces #773

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

This should not alter any outputs.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
