### PR TITLE
Cache `derating_factor` for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New resource type: Allam Cycle with Oxygen Storage (#772).
+- Caching of `derating_factor` to improve performance in model generation (#834).
 
 ## [0.4.4] - 2025-02-04
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenX"
 uuid = "5d317b1e-30ec-4ed6-a8ce-8d2d88d7cfac"
 authors = ["Bonaldo, Luca", "Chakrabarti, Sambuddha", "Cheng, Fangwei", "Ding, Yifu", "Jenkins, Jesse D.", "Luo, Qian", "Macdonald, Ruaridh", "Mallapragada, Dharik", "Manocha, Aneesha", "Mantegna, Gabe ", "Morris, Jack", "Patankar, Neha", "Pecci, Filippo", "Schwartz, Aaron", "Schwartz, Jacob", "Schivley, Greg", "Sepulveda, Nestor", "Xu, Qingyu", "Zhou, Justin"]
-version = "0.4.4-dev.2"
+version = "0.4.4-dev.3"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/load_inputs/load_cap_reserve_margin.jl
+++ b/src/load_inputs/load_cap_reserve_margin.jl
@@ -20,6 +20,10 @@ function load_cap_reserve_margin!(setup::Dict, path::AbstractString, inputs::Dic
     inputs["dfCapRes"] = mat
     inputs["NCapacityReserveMargin"] = size(mat, 2)
 
+    gen = inputs["RESOURCES"]
+    res = 1:inputs["NCapacityReserveMargin"]
+    inputs["DERATING_FACTOR"] = [derating_factor(g, tag = r) for g in gen, r = res]
+
     println(filename * " Successfully Read!")
 end
 

--- a/src/load_inputs/load_resources_data.jl
+++ b/src/load_inputs/load_resources_data.jl
@@ -1478,6 +1478,8 @@ function add_resources_to_input_data!(inputs::Dict,
     end
 
     inputs["RESOURCES"] = gen
+
+    inputs["DERATING_FACTOR"] = [derating_factor(g, tag = res) for g in gen, res = 1:inputs["NCapacityReserveMargin"]]
     return nothing
 end
 

--- a/src/load_inputs/load_resources_data.jl
+++ b/src/load_inputs/load_resources_data.jl
@@ -1478,7 +1478,6 @@ function add_resources_to_input_data!(inputs::Dict,
     end
 
     inputs["RESOURCES"] = gen
-
     return nothing
 end
 

--- a/src/load_inputs/load_resources_data.jl
+++ b/src/load_inputs/load_resources_data.jl
@@ -1479,7 +1479,6 @@ function add_resources_to_input_data!(inputs::Dict,
 
     inputs["RESOURCES"] = gen
 
-    inputs["DERATING_FACTOR"] = [derating_factor(g, tag = res) for g in gen, res = 1:inputs["NCapacityReserveMargin"]]
     return nothing
 end
 

--- a/src/model/resources/curtailable_variable_renewable/curtailable_variable_renewable.jl
+++ b/src/model/resources/curtailable_variable_renewable/curtailable_variable_renewable.jl
@@ -45,7 +45,7 @@ function curtailable_variable_renewable!(EP::Model, inputs::Dict, setup::Dict)
     if CapacityReserveMargin > 0
         @expression(EP,
             eCapResMarBalanceVRE[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(derating_factor(gen[y], tag = res) * EP[:eTotalCap][y] *
+            sum(inputs["DERATING_FACTOR"][y, res] * EP[:eTotalCap][y] *
                 inputs["pP_Max"][y, t] for y in VRE))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceVRE)
     end

--- a/src/model/resources/curtailable_variable_renewable/curtailable_variable_renewable.jl
+++ b/src/model/resources/curtailable_variable_renewable/curtailable_variable_renewable.jl
@@ -43,9 +43,11 @@ function curtailable_variable_renewable!(EP::Model, inputs::Dict, setup::Dict)
 
     # Capacity Reserves Margin policy
     if CapacityReserveMargin > 0
+        nCRMZones = inputs["NCapacityReserveMargin"]
+        capresfactor = inputs["DERATING_FACTOR"]
         @expression(EP,
-            eCapResMarBalanceVRE[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(inputs["DERATING_FACTOR"][y, res] * EP[:eTotalCap][y] *
+            eCapResMarBalanceVRE[res = 1:nCRMZones, t = 1:T],
+            sum(capresfactor[y, res] * EP[:eTotalCap][y] *
                 inputs["pP_Max"][y, t] for y in VRE))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceVRE)
     end

--- a/src/model/resources/flexible_ccs/allamcyclelox.jl
+++ b/src/model/resources/flexible_ccs/allamcyclelox.jl
@@ -240,9 +240,11 @@ function allamcyclelox!(EP::Model, inputs::Dict, setup::Dict)
     # Expressions related to policies
     # Capacity Reserves Margin policy
     if setup["CapacityReserveMargin"] > 0
+        nCRMZones = inputs["NCapacityReserveMargin"]
+        capresfactor = inputs["DERATING_FACTOR"]
         @expression(EP,
-            eCapResMarBalanceAllam[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(derating_factor(gen[y], tag = res) * (eP_Allam[y, t]-vCHARGE_ALLAM[y,t]) for y in ALLAM_CYCLE_LOX))
+            eCapResMarBalanceAllam[res = 1:nCRMZones, t = 1:T],
+            sum(capresfactor[y, res] * (eP_Allam[y, t]-vCHARGE_ALLAM[y,t]) for y in ALLAM_CYCLE_LOX))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceAllam)
     end
 

--- a/src/model/resources/flexible_demand/flexible_demand.jl
+++ b/src/model/resources/flexible_demand/flexible_demand.jl
@@ -74,7 +74,7 @@ function flexible_demand!(EP::Model, inputs::Dict, setup::Dict)
     if setup["CapacityReserveMargin"] > 0
         @expression(EP,
             eCapResMarBalanceFlex[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(derating_factor(gen[y], tag = res) *
+            sum(inputs["DERATING_FACTOR"][y, res]*
                 (EP[:vCHARGE_FLEX][y, t] - EP[:vP][y, t]) for y in FLEX))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceFlex)
     end

--- a/src/model/resources/flexible_demand/flexible_demand.jl
+++ b/src/model/resources/flexible_demand/flexible_demand.jl
@@ -72,9 +72,11 @@ function flexible_demand!(EP::Model, inputs::Dict, setup::Dict)
 
     # Capacity Reserves Margin policy
     if setup["CapacityReserveMargin"] > 0
+        nCRMZones = inputs["NCapacityReserveMargin"]
+        capresfactor = inputs["DERATING_FACTOR"]
         @expression(EP,
-            eCapResMarBalanceFlex[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(inputs["DERATING_FACTOR"][y, res]*
+            eCapResMarBalanceFlex[res = 1:nCRMZones, t = 1:T],
+            sum(capresfactor[y, res] *
                 (EP[:vCHARGE_FLEX][y, t] - EP[:vP][y, t]) for y in FLEX))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceFlex)
     end

--- a/src/model/resources/fusion/fusion_policy_adjustments.jl
+++ b/src/model/resources/fusion/fusion_policy_adjustments.jl
@@ -54,7 +54,7 @@ function fusion_capacity_reserve_margin_adjustment(EP::Model,
     component = gen[y]
     eTotalCap = EP[:eTotalCap][y]
 
-    capresfactor = derating_factor(component, tag=capres_zone)
+    capresfactor = inputs["DERATING_FACTOR"][component, capres_zone]
     if capresfactor == 0.0
         return AffExpr.(zero.(timesteps))
     end

--- a/src/model/resources/fusion/fusion_policy_adjustments.jl
+++ b/src/model/resources/fusion/fusion_policy_adjustments.jl
@@ -54,7 +54,7 @@ function fusion_capacity_reserve_margin_adjustment(EP::Model,
     component = gen[y]
     eTotalCap = EP[:eTotalCap][y]
 
-    capresfactor = inputs["DERATING_FACTOR"][component, capres_zone]
+    capresfactor = inputs["DERATING_FACTOR"][y, capres_zone]
     if capresfactor == 0.0
         return AffExpr.(zero.(timesteps))
     end

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -111,7 +111,7 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
     if setup["CapacityReserveMargin"] > 0
         @expression(EP,
             eCapResMarBalanceHydro[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(derating_factor(gen[y], tag = res) * EP[:vP][y, t] for y in HYDRO_RES))
+            sum(inputs["DERATING_FACTOR"][y, res] * EP[:vP][y, t] for y in HYDRO_RES))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceHydro)
     end
 

--- a/src/model/resources/hydro/hydro_res.jl
+++ b/src/model/resources/hydro/hydro_res.jl
@@ -109,9 +109,11 @@ function hydro_res!(EP::Model, inputs::Dict, setup::Dict)
 
     # Capacity Reserves Margin policy
     if setup["CapacityReserveMargin"] > 0
+        nCRMZones = inputs["NCapacityReserveMargin"]
+        capresfactor = inputs["DERATING_FACTOR"]
         @expression(EP,
-            eCapResMarBalanceHydro[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(inputs["DERATING_FACTOR"][y, res] * EP[:vP][y, t] for y in HYDRO_RES))
+            eCapResMarBalanceHydro[res = 1:nCRMZones, t = 1:T],
+            sum(capresfactor[y, res] * EP[:vP][y, t] for y in HYDRO_RES))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceHydro)
     end
 

--- a/src/model/resources/must_run/must_run.jl
+++ b/src/model/resources/must_run/must_run.jl
@@ -36,7 +36,7 @@ function must_run!(EP::Model, inputs::Dict, setup::Dict)
     if CapacityReserveMargin > 0
         @expression(EP,
             eCapResMarBalanceMustRun[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(derating_factor(gen[y], tag = res) * EP[:eTotalCap][y] *
+            sum(inputs["DERATING_FACTOR"][y, res] * EP[:eTotalCap][y] *
                 inputs["pP_Max"][y, t] for y in MUST_RUN))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceMustRun)
     end

--- a/src/model/resources/must_run/must_run.jl
+++ b/src/model/resources/must_run/must_run.jl
@@ -34,9 +34,11 @@ function must_run!(EP::Model, inputs::Dict, setup::Dict)
 
     # Capacity Reserves Margin policy
     if CapacityReserveMargin > 0
+        nCRMZones = inputs["NCapacityReserveMargin"]
+        capresfactor = inputs["DERATING_FACTOR"]
         @expression(EP,
-            eCapResMarBalanceMustRun[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-            sum(inputs["DERATING_FACTOR"][y, res] * EP[:eTotalCap][y] *
+            eCapResMarBalanceMustRun[res = 1:nCRMZones, t = 1:T],
+            sum(capresfactor[y, res] * EP[:eTotalCap][y] *
                 inputs["pP_Max"][y, t] for y in MUST_RUN))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceMustRun)
     end

--- a/src/model/resources/storage/storage.jl
+++ b/src/model/resources/storage/storage.jl
@@ -180,14 +180,15 @@ function storage!(EP::Model, inputs::Dict, setup::Dict)
         vP = EP[:vP]
         vCHARGE = EP[:vCHARGE]
         nCRMZones = inputs["NCapacityReserveMargin"]
+        capresfactor = inputs["DERATING_FACTOR"]
         @expression(EP,
             eCapResMarBalanceStor[res = 1:nCRMZones, t = 1:T],
-            sum(derating_factor(gen[y], tag = res) * (vP[y, t] - vCHARGE[y, t])
+            sum(capresfactor[y, res] * (vP[y, t] - vCHARGE[y, t])
             for y in STOR_ALL))
         if StorageVirtualDischarge > 0
             @expression(EP,
                 eCapResMarBalanceStorVirtual[res = 1:nCRMZones, t = 1:T],
-                sum(derating_factor(gen[y], tag = res) *
+                sum(capresfactor[y, res] *
                     (EP[:vCAPRES_discharge][y, t] - EP[:vCAPRES_charge][y, t])
                 for y in STOR_ALL))
             add_similar_to_expression!(eCapResMarBalanceStor, eCapResMarBalanceStorVirtual)

--- a/src/model/resources/thermal/thermal.jl
+++ b/src/model/resources/thermal/thermal.jl
@@ -33,7 +33,7 @@ function thermal!(EP::Model, inputs::Dict, setup::Dict)
     if setup["CapacityReserveMargin"] > 0
         ncapres = inputs["NCapacityReserveMargin"]
         @expression(EP, eCapResMarBalanceThermal[capres in 1:ncapres, t in 1:T],
-            sum(derating_factor(gen[y], tag = capres) * EP[:eTotalCap][y]
+            sum(inputs["DERATING_FACTOR"][y, capres] * EP[:eTotalCap][y]
             for y in THERM_ALL))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceThermal)
 

--- a/src/model/resources/thermal/thermal.jl
+++ b/src/model/resources/thermal/thermal.jl
@@ -31,9 +31,10 @@ function thermal!(EP::Model, inputs::Dict, setup::Dict)
 
     # Capacity Reserves Margin policy
     if setup["CapacityReserveMargin"] > 0
+        capresfactor = inputs["DERATING_FACTOR"]
         ncapres = inputs["NCapacityReserveMargin"]
         @expression(EP, eCapResMarBalanceThermal[capres in 1:ncapres, t in 1:T],
-            sum(inputs["DERATING_FACTOR"][y, capres] * EP[:eTotalCap][y]
+            sum(capresfactor[y, capres] * EP[:eTotalCap][y]
             for y in THERM_ALL))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceThermal)
 

--- a/src/model/resources/thermal/thermal_commit.jl
+++ b/src/model/resources/thermal/thermal_commit.jl
@@ -421,7 +421,7 @@ function thermal_maintenance_capacity_reserve_margin_adjustment(EP::Model,
         t)
     gen = inputs["RESOURCES"]
     resource_component = resource_name(gen[y])
-    capresfactor = derating_factor(gen[y], tag = capres)
+    capresfactor = inputs["DERATING_FACTOR"][y, capres]
     cap = cap_size(gen[y])
     down_var = EP[Symbol(maintenance_down_name(resource_component))]
     return -capresfactor * down_var[t] * cap

--- a/src/model/resources/vre_stor/vre_stor.jl
+++ b/src/model/resources/vre_stor/vre_stor.jl
@@ -2405,39 +2405,39 @@ function vre_stor_capres!(EP::Model, inputs::Dict, setup::Dict)
     # Constraint 3: Add capacity reserve margin contributions from VRE-STOR resources to capacity reserve margin constraint
     @expression(EP,
         eCapResMarBalanceStor_VRE_STOR[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-        (sum(derating_factor(gen[y], tag = res) * by_rid(y, :etainverter) *
+        (sum(inputs["DERATING_FACTOR"][y, res] * by_rid(y, :etainverter) *
              inputs["pP_Max_Solar"][y, t] * EP[:eTotalCap_SOLAR][y]
          for y in inputs["VS_SOLAR"])
          +
-         sum(derating_factor(gen[y], tag = res) * inputs["pP_Max_Wind"][y, t] *
+         sum(inputs["DERATING_FACTOR"][y, res] * inputs["pP_Max_Wind"][y, t] *
              EP[:eTotalCap_WIND][y] for y in inputs["VS_WIND"])
          +
-         sum(derating_factor(gen[y], tag = res) * by_rid(y, :etainverter) *
+         sum(inputs["DERATING_FACTOR"][y, res] * by_rid(y, :etainverter) *
              (EP[:vP_DC_DISCHARGE][y, t]) for y in DC_DISCHARGE)
          +
-         sum(derating_factor(gen[y], tag = res) * (EP[:vP_AC_DISCHARGE][y, t])
+         sum(inputs["DERATING_FACTOR"][y, res] * (EP[:vP_AC_DISCHARGE][y, t])
          for y in AC_DISCHARGE)
          -
-         sum(derating_factor(gen[y], tag = res) * (EP[:vP_DC_CHARGE][y, t]) /
+         sum(inputs["DERATING_FACTOR"][y, res] * (EP[:vP_DC_CHARGE][y, t]) /
              by_rid(y, :etainverter)
         for y in DC_CHARGE)
-        -sum(derating_factor(gen[y], tag = res) * (EP[:vP_AC_CHARGE][y, t])
+        -sum(inputs["DERATING_FACTOR"][y, res] * (EP[:vP_AC_CHARGE][y, t])
         for y in AC_CHARGE)))
     if StorageVirtualDischarge > 0
         @expression(EP,
             eCapResMarBalanceStor_VRE_STOR_Virtual[
                 res = 1:inputs["NCapacityReserveMargin"],
                 t = 1:T],
-            (sum(derating_factor(gen[y], tag = res) * by_rid(y, :etainverter) *
+            (sum(inputs["DERATING_FACTOR"][y, res] * by_rid(y, :etainverter) *
                  (vCAPRES_DC_DISCHARGE[y, t]) for y in DC_DISCHARGE)
              +
-             sum(derating_factor(gen[y], tag = res) * (vCAPRES_AC_DISCHARGE[y, t])
+             sum(inputs["DERATING_FACTOR"][y, res] * (vCAPRES_AC_DISCHARGE[y, t])
             for y in AC_DISCHARGE)
              -
-             sum(derating_factor(gen[y], tag = res) * (vCAPRES_DC_CHARGE[y, t]) /
+             sum(inputs["DERATING_FACTOR"][y, res] * (vCAPRES_DC_CHARGE[y, t]) /
                  by_rid(y, :etainverter)
             for y in DC_CHARGE)
-            -sum(derating_factor(gen[y], tag = res) * (vCAPRES_AC_CHARGE[y, t])
+            -sum(inputs["DERATING_FACTOR"][y, res] * (vCAPRES_AC_CHARGE[y, t])
             for y in AC_CHARGE)))
         add_similar_to_expression!(eCapResMarBalanceStor_VRE_STOR,
             eCapResMarBalanceStor_VRE_STOR_Virtual)

--- a/src/model/resources/vre_stor/vre_stor.jl
+++ b/src/model/resources/vre_stor/vre_stor.jl
@@ -2403,41 +2403,43 @@ function vre_stor_capres!(EP::Model, inputs::Dict, setup::Dict)
         EP[:vS_VRE_STOR][y, t]>=vCAPRES_VS_VRE_STOR[y, t])
 
     # Constraint 3: Add capacity reserve margin contributions from VRE-STOR resources to capacity reserve margin constraint
+    nCRMZones = inputs["NCapacityReserveMargin"]
+    capresfactor = inputs["DERATING_FACTOR"]
     @expression(EP,
-        eCapResMarBalanceStor_VRE_STOR[res = 1:inputs["NCapacityReserveMargin"], t = 1:T],
-        (sum(inputs["DERATING_FACTOR"][y, res] * by_rid(y, :etainverter) *
+        eCapResMarBalanceStor_VRE_STOR[res = 1:nCRMZones, t = 1:T],
+        (sum(capresfactor[y, res] * by_rid(y, :etainverter) *
              inputs["pP_Max_Solar"][y, t] * EP[:eTotalCap_SOLAR][y]
          for y in inputs["VS_SOLAR"])
          +
-         sum(inputs["DERATING_FACTOR"][y, res] * inputs["pP_Max_Wind"][y, t] *
+         sum(capresfactor[y, res] * inputs["pP_Max_Wind"][y, t] *
              EP[:eTotalCap_WIND][y] for y in inputs["VS_WIND"])
          +
-         sum(inputs["DERATING_FACTOR"][y, res] * by_rid(y, :etainverter) *
+         sum(capresfactor[y, res] * by_rid(y, :etainverter) *
              (EP[:vP_DC_DISCHARGE][y, t]) for y in DC_DISCHARGE)
          +
-         sum(inputs["DERATING_FACTOR"][y, res] * (EP[:vP_AC_DISCHARGE][y, t])
+         sum(capresfactor[y, res] * (EP[:vP_AC_DISCHARGE][y, t])
          for y in AC_DISCHARGE)
          -
-         sum(inputs["DERATING_FACTOR"][y, res] * (EP[:vP_DC_CHARGE][y, t]) /
+         sum(capresfactor[y, res] * (EP[:vP_DC_CHARGE][y, t]) /
              by_rid(y, :etainverter)
         for y in DC_CHARGE)
-        -sum(inputs["DERATING_FACTOR"][y, res] * (EP[:vP_AC_CHARGE][y, t])
+        -sum(capresfactor[y, res] * (EP[:vP_AC_CHARGE][y, t])
         for y in AC_CHARGE)))
     if StorageVirtualDischarge > 0
         @expression(EP,
             eCapResMarBalanceStor_VRE_STOR_Virtual[
-                res = 1:inputs["NCapacityReserveMargin"],
+                res = 1:nCRMZones,
                 t = 1:T],
-            (sum(inputs["DERATING_FACTOR"][y, res] * by_rid(y, :etainverter) *
+            (sum(capresfactor[y, res] * by_rid(y, :etainverter) *
                  (vCAPRES_DC_DISCHARGE[y, t]) for y in DC_DISCHARGE)
              +
-             sum(inputs["DERATING_FACTOR"][y, res] * (vCAPRES_AC_DISCHARGE[y, t])
+             sum(capresfactor[y, res] * (vCAPRES_AC_DISCHARGE[y, t])
             for y in AC_DISCHARGE)
              -
-             sum(inputs["DERATING_FACTOR"][y, res] * (vCAPRES_DC_CHARGE[y, t]) /
+             sum(capresfactor[y, res] * (vCAPRES_DC_CHARGE[y, t]) /
                  by_rid(y, :etainverter)
             for y in DC_CHARGE)
-            -sum(inputs["DERATING_FACTOR"][y, res] * (vCAPRES_AC_CHARGE[y, t])
+            -sum(capresfactor[y, res] * (vCAPRES_AC_CHARGE[y, t])
             for y in AC_CHARGE)))
         add_similar_to_expression!(eCapResMarBalanceStor_VRE_STOR,
             eCapResMarBalanceStor_VRE_STOR_Virtual)

--- a/src/write_outputs/capacity_reserve_margin/effective_capacity.jl
+++ b/src/write_outputs/capacity_reserve_margin/effective_capacity.jl
@@ -33,7 +33,7 @@ function thermal_plant_effective_capacity(EP::Model,
         timesteps::Vector{Int})::Vector{Float64}
     y = r_id
     gen = inputs["RESOURCES"]
-    capresfactor = derating_factor(gen[y], tag = capres_zone)
+    capresfactor = inputs["DERATING_FACTOR"][y, capres_zone]
     eTotalCap = value.(EP[:eTotalCap][y])
 
     effective_capacity = fill(capresfactor * eTotalCap, length(timesteps))


### PR DESCRIPTION
## Description

Calls to `derating_factor(g, tag = r)` are a bit expensive as they need to build strings in runtime.
It appears in many loops that involve time, so it shows up in profiling as something meaningful.

Here is a benchmark in a case with 26 areas and 10 weeks:

before:
`307.276451 seconds (399.25 M allocations: 24.051 GiB, 48.76% gc time)`

after:
`269.367580 seconds (332.77 M allocations: 20.677 GiB, 53.52% gc time)`

Which is 10% in time and almost 20%(!) in allocations.

## What type of PR is this? (check all applicable)

- [x] Performance Improvements

## Related Tickets & Documents

none

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [x] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [x] Code has been tested to ensure all functionality works as intended.
- [x] CHANGELOG.md has been updated (if this is a 'notable' change).
- [x] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

.

## Post-approval checklist for GenX core developers
After the PR is approved

- [x] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [x] Remember to squash and merge if incorporating into develop
