### PR TITLE
Fix assignment to AnnualSum in write_virtual_discharge (Only for Julia 1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Models running with, non-default, solvers Cbc and Clp will fail unless
 ### Fixed
 - Fix call to `get_retirement_stage` by casting `lifetime` to integer (#840).
 - Modify `storage_all.jl` to prevent micro-charging/discharging close to capacity (#836).
+- Got rid of brodcast operator src/write_outputs/capacity_reserve_margin/write_virtual_discharge.jl for preventing error with Julia 1.6 (#885)
+
 
 ### Changed
 - Replace `+=` and `-=` with `add_to_expression!` and `add_similar_to_expression!`

--- a/src/write_outputs/capacity_reserve_margin/write_virtual_discharge.jl
+++ b/src/write_outputs/capacity_reserve_margin/write_virtual_discharge.jl
@@ -17,7 +17,7 @@ function write_virtual_discharge(path::AbstractString, inputs::Dict, setup::Dict
                          value.(EP[:vCAPRES_charge][STOR_ALL, :].data)) * scale_factor
 
     dfVirtualDischarge = DataFrame(Resource = resources, Zone = zones)
-    dfVirtualDischarge.AnnualSum .= virtual_discharge * inputs["omega"]
+    dfVirtualDischarge.AnnualSum = virtual_discharge * inputs["omega"]
 
     filepath = joinpath(path, "virtual_discharge.csv")
     if setup["WriteOutputs"] == "annual"


### PR DESCRIPTION
Fix assignment to AnnualSum in write_virtual_discharge (Only for Julia 1.6)

This PR attempts to fix the ArgumentError in write_virtual_discharge.jl by getting rid of the broadcast operator

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

This section should include a detailed description of the motivation for the PR,
and a description of why it was implemented in the way that it was,
to the extent that these things are applicable.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Code Refactor
- [ ] Performance Improvements

## Related Tickets & Documents
<!-- 
Please use this format to link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and .md files under /docs/src have been updated if necessary.
- [ ] The latest changes on the target branch have been incorporated, so that any conflicts are taken care of before merging. This can be accomplished either by merging in the target branch (e.g. 'git merge develop') or by rebasing on top of the target branch (e.g. 'git rebase develop'). Please do not hesitate to reach out to the GenX development team if you need help with this.
- [ ] Code has been tested to ensure all functionality works as intended.
- [ ] CHANGELOG.md has been updated (if this is a 'notable' change).
- [ ] I consent to the release of this PR's code under the GNU General Public license.

## How this can be tested

<!--
If applicable: What cases should we try before/after? Will this alter any outputs, or is it a strictly internal change?
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  After the PR is approved we will give you a chance to tidy up the branch before merging.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. In the case of large feature or module additions, it is best to work towards a "minimum viable product" that is thoroughly tested but may not have all desired functionality or features, make a PR for this, and then later work to add more features.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.

-->

## Post-approval checklist for GenX core developers
After the PR is approved

- [ ] Check that the latest changes on the target branch are incorporated, either via merge or rebase
- [ ] Remember to squash and merge if incorporating into develop
